### PR TITLE
Use LBR instead of dwarf call-graph.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@ mod arch {
     ) -> Command {
         let mut command = Command::new("perf");
 
-        for arg in "record -F 99 --call-graph dwarf -g"
+        for arg in "record -F 99 --call-graph lbr -g"
             .split_whitespace()
         {
             command.arg(arg);
@@ -125,8 +125,10 @@ fn terminated_by_error(status: ExitStatus) -> bool {
     status
         .signal() // the default needs to be true because that's the neutral element for `&&`
         .map_or(true, |code| {
-            code != signal_hook::SIGINT && code != signal_hook::SIGTERM
-        }) && !status.success()
+            code != signal_hook::SIGINT
+                && code != signal_hook::SIGTERM
+        })
+        && !status.success()
 }
 
 #[cfg(not(unix))]
@@ -147,7 +149,7 @@ pub fn generate_flamegraph_by_running_command<
     // SIGINT signal to all processes in the foreground
     // process group).
     let handler = unsafe {
-        signal_hook::register(signal_hook::SIGINT, || { })
+        signal_hook::register(signal_hook::SIGINT, || {})
             .expect("cannot register signal handler")
     };
 


### PR DESCRIPTION
This option is viable on Haswell or later Intel platforms. It is much
lower overhead while profiling, generates more compact perf data, and is
much quicker to collapse and generate flame graphs.

The downsides is that it has limited stack depth, does not work on major
cloud providers and some others listed at
https://lwn.net/Articles/617097/ and
http://www.brendangregg.com/perf.html

Would you be interested in a change like this?  I'm also happy to make it configurable by env var of flag if you provide some guidance.