### PR TITLE
Modify installation instructions for Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ increase your team's skills, get in touch :D
 
 Requirements on Linux (Ubuntu/Debian):
 ```
-sudo apt install -y linux-tools-common linux-tools-generic
+sudo apt install -y linux-tools-common linux-tools-generic linux-tools-`uname -r`
 ```
 
 `flamegraph` not `cargo-flamegraph`! (`cargo-flamegraph` is an inactive crate as of March 2019)


### PR DESCRIPTION
Thanks for providing this great tool!

I ran into the following error when running on Ubuntu 18.04 with Linux 5.3.0-28-generic:
```
WARNING: perf not found for kernel 5.3.0-28

  You may need to install the following packages for this specific kernel:
    linux-tools-5.3.0-28-generic
    linux-cloud-tools-5.3.0-28-generic

  You may also want to install one of the following packages to keep up to date:
    linux-tools-generic
    linux-cloud-tools-generic
failed to sample program
```
(just running `perf` by itself gives very similar output)

Following https://askubuntu.com/questions/50145/how-to-install-perf-monitoring-tool, I installed ``linux-tools-`uname -r` ``, which fixed the error for me. This is apparently necessary when not running an up-to-date kernel. Maybe it makes sense to add this to the readme in case others have a similar problem.