### PR TITLE
Fix checking for debuginfo

### DIFF
--- a/src/bin/cargo-flamegraph.rs
+++ b/src/bin/cargo-flamegraph.rs
@@ -157,7 +157,12 @@ fn build(opt: &Opt) {
                 continue;
             };
 
-            if workload(opt).contains(&artifact.target.name)
+            // Since workload() returns a Vec of paths, artifact.target.name could be contained in
+            // the path (e.g. in the project name). Thus .ends_with() is required to ensure the
+            // actual binary name is matched.
+            if workload(opt)
+                .iter()
+                .any(|w| w.ends_with(&artifact.target.name))
                 && artifact.profile.debuginfo.unwrap_or(0)
                     != 0
             {
@@ -166,10 +171,11 @@ fn build(opt: &Opt) {
         }
 
         if !has_debuginfo {
-            let mut profile = "release";
-            if opt.bench.is_some() {
-                profile = "bench";
-            }
+            let profile = if opt.bench.is_some() {
+                "bench"
+            } else {
+                "release"
+            };
             eprintln!(
                 "\nWARNING: building without debuginfo. \
                  Enable symbol information by adding \


### PR DESCRIPTION
This pull request fixes checking for debuginfo in non-dev builds. It most likely fixes #71 although I haven't tested it on workspace projects.

It also gets rid of an unnecessarily mutable variable that was in my view. 