### PR TITLE
Fix 'extraneous argument' error on macOS

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,7 +129,7 @@ mod arch {
         match workload {
             Workload::Command(c) => {
                 command.arg("-c");
-                command.args(&c);
+                command.arg(&c.join(" "));
             }
             Workload::Pid(p) => {
                 command.arg("-p");


### PR DESCRIPTION
See "The second one" in #72. I noticed

```
dtrace: invalid probe specifier profile-997 /pid == $target/ { @[ustack(100)] = count(); }: extraneous argument 'my_arg' ($1 is not referenced)
failed to sample program
```

when using `flamegraph-rs` on macOS:

```
sudo cargo flamegraph --bin=my_binary -- my_arg
```

It looks like we're passing the command string, `path/to/my_binary my_arg` as multiple arguments, prefixed by flag `-c`. We should pass them as a *single* argument, prefixed by flag `-c`, as if they were quoted:

```
sudo dtrace -c './path/to/my_binary my_arg' ...
```

Changing `.args()` to `.arg()` resolves the "extraneous argument" error.

macOS (10.15.5)
flamegraph-rs 0.3.0
dtrace 1.15