### PR TITLE
Don't spend time optimizing build deps, such as proc macros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,6 @@ opener = "0.4.1"
 
 [target.'cfg(unix)'.dependencies]
 signal-hook = "0.1.15"
+
+[profile.release.build-override]
+opt-level = 0


### PR DESCRIPTION
A build of flamegraph spends time optimizing various proc macros and
their dependencies, when they'll only run at build time and never at
runtime. Building them without optimizations substantially speeds up
the build, without affecting runtime performance at all.

Before:
    Finished release [optimized] target(s) in 2m 35s

After:
    Finished release [optimized] target(s) in 1m 31s