### PR TITLE
Restore default sample rate of 997

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@ mod arch {
 
         let args = custom_cmd.unwrap_or(format!(
             "record -F {} --call-graph dwarf -g",
-            freq.unwrap_or(99)
+            freq.unwrap_or(997)
         ));
 
         for arg in args.split_whitespace() {


### PR DESCRIPTION
https://github.com/flamegraph-rs/flamegraph/pull/33#diff-b4aea3e418ccdb71239b96952d9cddb6L107 modified the sample rate from 997 to 99, which often isn't enough resolution to capture short-lived events. This restores the sample rate to `997`, which should provide more granularity without significantly increasing overhead. Thanks!