### PR TITLE
Detect '-o' argument in custom command.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@ mod arch {
         sudo: bool,
         freq: Option<u32>,
         custom_cmd: Option<String>,
-    ) -> Command {
+    ) -> (Command, Option<String>) {
         let perf = env::var("PERF")
             .unwrap_or_else(|_| "perf".to_string());
 
@@ -65,8 +65,22 @@ mod arch {
             freq.unwrap_or(997)
         ));
 
-        for arg in args.split_whitespace() {
+        let mut perf_output = None;
+        let mut args = args.split_whitespace();
+        while let Some(arg) = args.next() {
             command.arg(arg);
+
+            // Detect if user is setting `perf record`
+            // output file with `-o`. If so, save it in
+            // order to correctly compute perf's output in
+            // `Self::output`.
+            if arg == "-o" {
+                let next_arg = args
+                    .next()
+                    .expect("missing '-o' argument");
+                command.arg(next_arg);
+                perf_output = Some(next_arg.to_string());
+            }
         }
 
         match workload {
@@ -79,14 +93,19 @@ mod arch {
             }
         }
 
-        command
+        (command, perf_output)
     }
 
-    pub fn output() -> Vec<u8> {
+    pub fn output(perf_output: Option<String>) -> Vec<u8> {
         let perf = env::var("PERF")
             .unwrap_or_else(|_| "perf".to_string());
-        Command::new(perf)
-            .arg("script")
+        let mut command = Command::new(perf);
+        command.arg("script");
+        if let Some(perf_output) = perf_output {
+            command.arg("-i");
+            command.arg(perf_output);
+        }
+        command
             .output()
             .expect("unable to call perf script")
             .stdout
@@ -108,7 +127,7 @@ mod arch {
         sudo: bool,
         freq: Option<u32>,
         custom_cmd: Option<String>,
-    ) -> Command {
+    ) -> (Command, Option<String>) {
         let dtrace = env::var("DTRACE")
             .unwrap_or_else(|_| "dtrace".to_string());
 
@@ -146,10 +165,10 @@ mod arch {
             }
         }
 
-        command
+        (command, None)
     }
 
-    pub fn output() -> Vec<u8> {
+    pub fn output(_: Option<String>) -> Vec<u8> {
         let mut buf = vec![];
         let mut f = File::open("cargo-flamegraph.stacks")
             .expect(
@@ -210,7 +229,7 @@ pub fn generate_flamegraph_for_workload<
             .expect("cannot register signal handler")
     };
 
-    let mut command = arch::initial_command(
+    let (mut command, perf_output) = arch::initial_command(
         workload, sudo, freq, custom_cmd,
     );
 
@@ -232,7 +251,7 @@ pub fn generate_flamegraph_for_workload<
         std::process::exit(1);
     }
 
-    let output = arch::output();
+    let output = arch::output(perf_output);
 
     let perf_reader = BufReader::new(&*output);
 


### PR DESCRIPTION
Previously, if argument `-o` was set in the custom command, `flamegraph` would fail to compute perf's output since it would look for the default `perf.data` file.

Now, we detect if the user sets perf's output file with `-o` and build the flamegraph from that file instead.

With this change, the following command now seems to work:
```
flamegraph -c "record -F 997 --call-graph dwarf -g -o my_perf.data" date
Fri Jul 31 12:02:05 CEST 2020
[ perf record: Woken up 1 times to write data ]
[ perf record: Captured and wrote 0.075 MB my_perf.data (7 samples) ]
writing flamegraph to "flamegraph.svg"
```

Without this change, this is the error we get:
```
flamegraph -c "record -F 997 --call-graph dwarf -g -o my_perf.data" date
Fri Jul 31 12:03:08 CEST 2020
[ perf record: Woken up 1 times to write data ]
[ perf record: Captured and wrote 0.075 MB my_perf.data (7 samples) ]
writing flamegraph to "flamegraph.svg"
thread 'main' panicked at 'unable to generate a flamegraph from the collapsed stack data: Io(Custom { kind: InvalidData, error: "No stack counts found" })', /home/vitor.enes/.cargo/registry/src/github.com-1ecc6299db9ec823/flamegraph-0.3.1/src/lib.rs:273:6
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```