### PR TITLE
add -p/--package option

### DIFF
--- a/src/bin/cargo-flamegraph.rs
+++ b/src/bin/cargo-flamegraph.rs
@@ -14,6 +14,10 @@ struct Opt {
     #[structopt(long = "dev")]
     dev: bool,
 
+    /// package with the binary to run
+    #[structopt(short = "p", long = "package")]
+    package: Option<String>,
+
     /// Binary to run
     #[structopt(
         short = "b",
@@ -102,6 +106,11 @@ fn build(opt: &Opt) {
 
     if !opt.dev {
         cmd.arg("--release");
+    }
+
+    if let Some(ref package) = opt.package {
+        cmd.arg("--package");
+        cmd.arg(package);
     }
 
     if let Some(ref bin) = opt.bin {


### PR DESCRIPTION
Fixes #93 by adding an option -p/--package. The option gets forwarded to cargo to allow the user to choose a sub-crate in a workspace.