### PR TITLE
find right path of binary files

### DIFF
--- a/src/bin/cargo-flamegraph.rs
+++ b/src/bin/cargo-flamegraph.rs
@@ -246,13 +246,12 @@ fn workload(opt: &Opt) -> Vec<String> {
 
     if opt.dev {
         binary_path.push("debug");
+    } else if opt.example.is_some() {
+        binary_path.push("examples");
     } else {
         binary_path.push("release");
     }
-
-    if opt.example.is_some() {
-        binary_path.push("examples");
-    }
+    binary_path.push("deps");
 
     let targets: Vec<String> = metadata
         .packages


### PR DESCRIPTION
I'm not able to find the right path of binary automatically -- as i've moved the binary file from the `deps` folder to the upper level of `release` folder, the problem was solved. 