### PR TITLE
Escape space when passing commands to arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,13 +73,12 @@ checksum = "db7a1029718df60331e557c9e83a55523c955e5dd2a7bfeffad6bbd50b538ae9"
 
 [[package]]
 name = "cargo_metadata"
-version = "0.10.0"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8de60b887edf6d74370fc8eb177040da4847d971d6234c7b13a6da324ef0caf"
+checksum = "e708746e51dfaeff27c6c3979a4005a7faddabe40144204a0b1ce5ad34a1d0a5"
 dependencies = [
  "semver",
  "serde",
- "serde_derive",
  "serde_json",
 ]
 
@@ -290,9 +289,9 @@ dependencies = [
 
 [[package]]
 name = "inferno"
-version = "0.9.9"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2a71c56e4c218f2a1d36bc5177cbfdedf89697ac68610ac3c8452cde152231"
+checksum = "e4eb1402c92d29c8b44e090b9b0fc25f5714253f959c9f42e378b91cff4d952f"
 dependencies = [
  "ahash",
  "crossbeam",
@@ -499,9 +498,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "semver"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+checksum = "394cec28fa623e00903caf7ba4fa6fb9a0e260280bb8cdbbba029611108a0190"
 dependencies = [
  "semver-parser",
  "serde",
@@ -518,6 +517,9 @@ name = "serde"
 version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5317f7588f0a5078ee60ef675ef96735a1442132dc645eb1d12c018620ed8cd3"
+dependencies = [
+ "serde_derive",
+]
 
 [[package]]
 name = "serde_derive"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,9 @@ name = "flamegraph"
 path = "src/bin/flamegraph.rs"
 
 [dependencies]
-inferno = "0.9.8"
+inferno = "0.10.0"
 structopt = "0.3.14"
-cargo_metadata = "0.10.0"
+cargo_metadata = "0.11.3"
 opener = "0.4.1"
 
 [target.'cfg(unix)'.dependencies]

--- a/src/bin/cargo-flamegraph.rs
+++ b/src/bin/cargo-flamegraph.rs
@@ -280,7 +280,7 @@ fn workload(opt: &Opt) -> Vec<String> {
     } else if let Some(ref bench) = opt.bench {
         find_binary("bench", &binary_path, bench)
     } else if let Some(ref bin) =
-        opt.bin.as_ref().or(opt.example.as_ref())
+        opt.bin.as_ref().or_else(|| opt.example.as_ref())
     {
         if targets.contains(&bin) {
             bin.to_string()
@@ -324,7 +324,7 @@ fn main() {
     let flamegraph_filename: PathBuf = opt
         .output
         .take()
-        .unwrap_or("flamegraph.svg".into());
+        .unwrap_or_else(|| "flamegraph.svg".into());
 
     flamegraph::generate_flamegraph_for_workload(
         Workload::Command(workload),

--- a/src/bin/cargo-flamegraph.rs
+++ b/src/bin/cargo-flamegraph.rs
@@ -71,6 +71,10 @@ struct Opt {
     #[structopt(long = "root")]
     root: bool,
 
+    /// Print extra output to help debug problems
+    #[structopt(short = "v", long = "verbose")]
+    verbose: bool,
+
     /// Sampling frequency
     #[structopt(short = "F", long = "freq")]
     frequency: Option<u32>,
@@ -127,6 +131,10 @@ fn build(opt: &Opt) {
     if let Some(ref features) = opt.features {
         cmd.arg("--features");
         cmd.arg(features);
+    }
+
+    if opt.verbose {
+        println!("build command: {:?}", cmd);
     }
 
     let mut child = cmd
@@ -309,6 +317,9 @@ fn main() {
     build(&opt);
 
     let workload = workload(&opt);
+    if opt.verbose {
+        println!("workload: {:?}", workload);
+    }
 
     let flamegraph_filename: PathBuf = opt
         .output
@@ -321,6 +332,7 @@ fn main() {
         opt.root,
         opt.frequency,
         opt.custom_cmd,
+        opt.verbose,
     );
 
     if opt.open {

--- a/src/bin/flamegraph.rs
+++ b/src/bin/flamegraph.rs
@@ -79,7 +79,7 @@ fn main() {
     let flamegraph_filename: PathBuf = opt
         .output
         .take()
-        .unwrap_or("flamegraph.svg".into());
+        .unwrap_or_else(|| "flamegraph.svg".into());
 
     flamegraph::generate_flamegraph_for_workload(
         workload,

--- a/src/bin/flamegraph.rs
+++ b/src/bin/flamegraph.rs
@@ -33,6 +33,10 @@ struct Opt {
     #[structopt(short = "F", long = "freq")]
     frequency: Option<u32>,
 
+    /// Print extra output to help debug problems
+    #[structopt(short = "v", long = "verbose")]
+    verbose: bool,
+
     /// Custom command for invoking perf/dtrace
     #[structopt(
         short = "c",
@@ -83,6 +87,7 @@ fn main() {
         opt.root,
         opt.frequency,
         opt.custom_cmd,
+        opt.verbose,
     );
 
     if opt.open {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,6 +206,7 @@ pub fn generate_flamegraph_for_workload<
     sudo: bool,
     freq: Option<u32>,
     custom_cmd: Option<String>,
+    verbose: bool,
 ) {
     // Handle SIGINT with an empty handler. This has the
     // implicit effect of allowing the signal to reach the
@@ -222,6 +223,9 @@ pub fn generate_flamegraph_for_workload<
     let mut command = arch::initial_command(
         workload, sudo, freq, custom_cmd,
     );
+    if verbose {
+        println!("command {:?}", command);
+    }
 
     let mut recorder =
         command.spawn().expect(arch::SPAWN_ERROR);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,8 +137,17 @@ mod arch {
 
         match workload {
             Workload::Command(c) => {
+                let mut escaped = String::new();
+                for (i, arg) in c.iter().enumerate() {
+                    if i > 0 {
+                        escaped.push(' ');
+                    }
+                    escaped
+                        .push_str(&arg.replace(" ", "\\ "));
+                }
+
                 command.arg("-c");
-                command.args(&c);
+                command.arg(&escaped);
             }
             Workload::Pid(p) => {
                 command.arg("-p");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,9 +25,6 @@ use inferno::{
     },
 };
 
-#[cfg(unix)]
-use signal_hook;
-
 pub enum Workload {
     Command(Vec<String>),
     Pid(u32),
@@ -37,11 +34,9 @@ pub enum Workload {
 mod arch {
     use super::*;
 
-    pub const SPAWN_ERROR: &'static str =
-        "could not spawn perf";
-    pub const WAIT_ERROR: &'static str =
-        "unable to wait for perf \
-         child command to exit";
+    pub const SPAWN_ERROR: &str = "could not spawn perf";
+    pub const WAIT_ERROR: &str =
+        "unable to wait for perf child command to exit";
 
     pub(crate) fn initial_command(
         workload: Workload,


### PR DESCRIPTION
Both of the fixes proposed in #88 don't work for me:

```diff
diff --git a/src/lib.rs b/src/lib.rs
index a83fd94..dde4adb 100644
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,7 +129,7 @@ mod arch {
         match workload {
             Workload::Command(c) => {
                 command.arg("-c");
-                command.args(&c);
+                command.arg(&c.join(" "));
             }
             Workload::Pid(p) => {
                 command.arg("-p");
```

or 

```diff

diff --git a/src/lib.rs b/src/lib.rs
index dde4adb..4acd0b2 100644
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,7 +127,12 @@ mod arch {
         command.arg("cargo-flamegraph.stacks");
 
         match workload {
-            Workload::Command(c) => {
+            Workload::Command(mut c) => {
+                // dtrace does not preserve quoting in the string passed via -c, so to pass along
+                // multi-word arguments we need to escape any whitespace within each arg.
+                for arg in c[1..].iter_mut() {
+                    *arg = arg.replace(" ", "\\ ")
+                }
                 command.arg("-c");
                 command.arg(&c.join(" "));
             }
```

So I came up with a new version that at least seems to work for me. @vlthr would you mind checking my work? @spacejam I noticed the work in #88 has been sitting there for a while, but this issue makes flamegraph quite a pain to use on macOS. Please consider reviewing and releasing this (or something like it).

(Also I'm happy to help out with maintaining this project if you prefer.)