### PR TITLE
Workaround #32 - fails parsing invalid utf8 dtrace output (macos only?)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,7 +169,22 @@ mod arch {
                  temporary file",
             );
 
-        buf
+        // Workaround #32 - fails parsing invalid utf8 dtrace output
+        //
+        // Intermittently, invalid utf-8 is found in cargo-flamegraph.stacks, which
+        // causes parsing to blow up with the error:
+        //
+        // > unable to collapse generated profile data: Custom { kind: InvalidData, error: StringError("stream did not contain valid UTF-8") }
+        //
+        // So here we just lossily re-encode to hopefully work around the underlying problem
+        let string = String::from_utf8_lossy(&buf);
+        let reencoded_buf = string.as_bytes().to_owned();
+
+        if reencoded_buf != buf {
+            println!("Lossily converted invalid utf-8 found in cargo-flamegraph.stacks");
+        }
+
+        reencoded_buf
     }
 }
 


### PR DESCRIPTION
Intermittently, invalid utf-8 is found in cargo-flamegraph.stacks, which causes parsing to blow up with the error:

> unable to collapse generated profile data: Custom { kind: InvalidData, error: StringError("stream did not contain valid UTF-8") }

This commit doesn't fix the underlying problem, but simply works around
it by lossily re-encoding to valid utf8.

Anecdotally it seems to be macos symbol names at the end of the line that
contain the invalid utf-8 - I don't know if this is due to some error in dtrace
or if somehow the symbols actually contain non utf-8 encodings.

Note I did try explicitly specifying utf8 output, by adding to the
dtrace command invocation:

    command.arg("-x");
    command.arg("encoding=utf8");

But I ran into the same error seemingly just as often.

---

This is admittedly a hack, so I understand if you don't want to merge it, but it might be helpful for folks like me experiencing #32. 

Anecdotally this commit seems to completely fix things for me. Without it I get the above error about 50% of the time — making it quite frustrating to use this otherwise very nice tool. 🙂 

The caveat is that presumably the invalid symbol names will not be correctly labeled/classified, but in practice this hasn't bitten me yet, since it seems to be a relatively small number of affected lines.