### PR TITLE
Append 'deps' to binary_path when running benches

### DIFF
--- a/src/bin/cargo-flamegraph.rs
+++ b/src/bin/cargo-flamegraph.rs
@@ -252,6 +252,8 @@ fn workload(opt: &Opt) -> Vec<String> {
 
     if opt.example.is_some() {
         binary_path.push("examples");
+    } else if opt.bench.is_some() {
+        binary_path.push("deps");
     }
 
     let targets: Vec<String> = metadata


### PR DESCRIPTION
I was only able to test this for libraries (I tested [comrak](https://crates.io/crates/comrak)).

Without this, no benches are found with `cargo +nightly flamegraph --bench progit`.

With this change, the benchmark runs fine and a flamegraph got created.