### PR TITLE
Read target triple from environment

### DIFF
--- a/src/bin/cargo-flamegraph.rs
+++ b/src/bin/cargo-flamegraph.rs
@@ -244,6 +244,10 @@ fn workload(opt: &Opt) -> Vec<String> {
 
     let mut binary_path = metadata.target_directory;
 
+    if let Ok(t) = std::env::var("CARGO_BUILD_TARGET") {
+        binary_path.push(t);
+    }
+
     if opt.dev {
         binary_path.push("debug");
     } else {


### PR DESCRIPTION
When `$CARGO_BUILD_TARGET` or `--target` is specified, the build artifacts end up in the directory `./target/$target_triple`. Use case: generating flamegraphs for `x86_64-unknown-linux-musl` on a GNU linux build machine.