### PR TITLE
Add --image-width

### DIFF
--- a/src/bin/cargo-flamegraph.rs
+++ b/src/bin/cargo-flamegraph.rs
@@ -95,6 +95,10 @@ struct Opt {
     )]
     custom_cmd: Option<String>,
 
+    /// Image width in pixels
+    #[structopt(long = "image-width")]
+    image_width: Option<usize>,
+
     trailing_arguments: Vec<String>,
 }
 
@@ -355,6 +359,7 @@ fn main() {
         opt.root,
         opt.frequency,
         opt.custom_cmd,
+        opt.image_width,
         opt.verbose,
     );
 

--- a/src/bin/flamegraph.rs
+++ b/src/bin/flamegraph.rs
@@ -45,6 +45,10 @@ struct Opt {
     )]
     custom_cmd: Option<String>,
 
+    /// Image width in pixels
+    #[structopt(long = "image-width")]
+    image_width: Option<usize>,
+
     trailing_arguments: Vec<String>,
 }
 
@@ -87,6 +91,7 @@ fn main() {
         opt.root,
         opt.frequency,
         opt.custom_cmd,
+        opt.image_width,
         opt.verbose,
     );
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,6 +227,9 @@ fn terminated_by_error(status: ExitStatus) -> bool {
     !status.success()
 }
 
+// False positive in clippy for non-exhaustive struct FlamegraphOptions:
+// https://github.com/rust-lang/rust-clippy/issues/6559
+#[allow(clippy::field_reassign_with_default)]
 pub fn generate_flamegraph_for_workload<
     P: AsRef<std::path::Path>,
 >(
@@ -235,6 +238,7 @@ pub fn generate_flamegraph_for_workload<
     sudo: bool,
     freq: Option<u32>,
     custom_cmd: Option<String>,
+    image_width: Option<usize>,
     verbose: bool,
 ) {
     // Handle SIGINT with an empty handler. This has the
@@ -306,6 +310,7 @@ pub fn generate_flamegraph_for_workload<
 
     let mut flamegraph_options =
         FlamegraphOptions::default();
+    flamegraph_options.image_width = image_width;
 
     from_reader(
         &mut flamegraph_options,


### PR DESCRIPTION
Fixes #109 by adding the command-line option `--image-width`. The specified value is passed directly to Inferno's [`Options`](https://docs.rs/inferno/0.10.2/inferno/flamegraph/struct.Options.html#structfield.image_width).