### PR TITLE
Add no-inline option

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ usually something like `~/.cargo/bin`.
 # if you'd like to profile an arbitrary executable:
 flamegraph [-o my_flamegraph.svg] /path/to/my/binary --my-arg 5
 
+# NOTE: By default, perf tries to compute which functions are
+# inlined at every stack frame for every sample. This can take
+# a very long time (see https://github.com/flamegraph-rs/flamegraph/issues/74).
+# If you don't want this, you can pass --no-inline to flamegraph:
+flamegraph --no-inline [-o my_flamegraph.svg] /path/to/my/binary --my-arg 5
+
 # cargo support provided through the cargo-flamegraph binary!
 # defaults to profiling cargo run --release
 cargo flamegraph

--- a/src/bin/cargo-flamegraph.rs
+++ b/src/bin/cargo-flamegraph.rs
@@ -99,6 +99,10 @@ struct Opt {
     )]
     custom_cmd: Option<String>,
 
+    /// Disable inlining for perf script because of performace issues
+    #[structopt(long = "no-inline")]
+    script_no_inline: bool,
+
     #[structopt(flatten)]
     flamegraph_options: flamegraph::FlamegraphOptions,
 
@@ -386,6 +390,7 @@ fn main() {
         Workload::Command(workload),
         &flamegraph_filename,
         opt.root,
+        opt.script_no_inline,
         opt.frequency,
         opt.custom_cmd,
         opt.flamegraph_options.into_inferno(),

--- a/src/bin/flamegraph.rs
+++ b/src/bin/flamegraph.rs
@@ -45,7 +45,7 @@ struct Opt {
     )]
     custom_cmd: Option<String>,
 
-    /// Disable inlining for perf script because of performace issues
+    /// Disable inlining for perf script because of performance issues
     #[structopt(long = "no-inline")]
     script_no_inline: bool,
 

--- a/src/bin/flamegraph.rs
+++ b/src/bin/flamegraph.rs
@@ -44,6 +44,10 @@ struct Opt {
         conflicts_with = "freq"
     )]
     custom_cmd: Option<String>,
+    
+    /// Disable inlining for perf script because of performace issues
+    #[structopt(long = "no-inline")]
+    script_no_inline: bool,
 
     #[structopt(flatten)]
     flamegraph_options: flamegraph::FlamegraphOptions,
@@ -88,6 +92,7 @@ fn main() {
         workload,
         &flamegraph_filename,
         opt.root,
+        opt.script_no_inline,
         opt.frequency,
         opt.custom_cmd,
         opt.flamegraph_options.into_inferno(),

--- a/src/bin/flamegraph.rs
+++ b/src/bin/flamegraph.rs
@@ -44,7 +44,7 @@ struct Opt {
         conflicts_with = "freq"
     )]
     custom_cmd: Option<String>,
-    
+
     /// Disable inlining for perf script because of performace issues
     #[structopt(long = "no-inline")]
     script_no_inline: bool,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,7 +176,10 @@ mod arch {
         (command, None)
     }
 
-    pub fn output(_: Option<String>, script_no_inline: bool) -> Vec<u8> {
+    pub fn output(
+        _: Option<String>,
+        script_no_inline: bool,
+    ) -> Vec<u8> {
         if script_no_inline {
             eprintln!("Option --no-inline is only supported on linux systems.");
             std::process::exit(1);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,7 +176,11 @@ mod arch {
         (command, None)
     }
 
-    pub fn output(_: Option<String>, _: bool) -> Vec<u8> {
+    pub fn output(_: Option<String>, script_no_inline: bool) -> Vec<u8> {
+        if script_no_inline {
+            eprintln!("Option --no-inline is only supported on linux systems.");
+            std::process::exit(1);
+        }
         let mut buf = vec![];
         let mut f = File::open("cargo-flamegraph.stacks")
             .expect(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,11 +89,14 @@ mod arch {
         (command, perf_output)
     }
 
-    pub fn output(perf_output: Option<String>) -> Vec<u8> {
+    pub fn output(perf_output: Option<String>, script_no_inline: bool) -> Vec<u8> {
         let perf = env::var("PERF")
             .unwrap_or_else(|_| "perf".to_string());
         let mut command = Command::new(perf);
         command.arg("script");
+        if script_no_inline {
+            command.arg("--no-inline");
+        }
         if let Some(perf_output) = perf_output {
             command.arg("-i");
             command.arg(perf_output);
@@ -170,7 +173,7 @@ mod arch {
         (command, None)
     }
 
-    pub fn output(_: Option<String>) -> Vec<u8> {
+    pub fn output(_: Option<String>, _: bool) -> Vec<u8> {
         let mut buf = vec![];
         let mut f = File::open("cargo-flamegraph.stacks")
             .expect(
@@ -234,6 +237,7 @@ pub fn generate_flamegraph_for_workload<
     workload: Workload,
     flamegraph_filename: P,
     sudo: bool,
+    script_no_inline: bool,
     freq: Option<u32>,
     custom_cmd: Option<String>,
     mut flamegraph_options: inferno::flamegraph::Options,
@@ -276,7 +280,7 @@ pub fn generate_flamegraph_for_workload<
         std::process::exit(1);
     }
 
-    let output = arch::output(perf_output);
+    let output = arch::output(perf_output, script_no_inline);
 
     let perf_reader = BufReader::new(&*output);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,10 @@ mod arch {
         (command, perf_output)
     }
 
-    pub fn output(perf_output: Option<String>, script_no_inline: bool) -> Vec<u8> {
+    pub fn output(
+        perf_output: Option<String>,
+        script_no_inline: bool,
+    ) -> Vec<u8> {
         let perf = env::var("PERF")
             .unwrap_or_else(|_| "perf".to_string());
         let mut command = Command::new(perf);
@@ -280,7 +283,8 @@ pub fn generate_flamegraph_for_workload<
         std::process::exit(1);
     }
 
-    let output = arch::output(perf_output, script_no_inline);
+    let output =
+        arch::output(perf_output, script_no_inline);
 
     let perf_reader = BufReader::new(&*output);
 


### PR DESCRIPTION
Fixes #74 and #126

This is how to use it:
```sh
flamegraph --no-inline -o flamegraph.svg [COMMAND]
```