### PR TITLE
Profile unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ cargo flamegraph -c "record -e branch-misses -c 100 --call-graph lbr -g"
 cargo flamegraph --bench some_benchmark --features some_features -- --bench`
 
 cargo flamegraph --example some_example --features some_features
+
+# Profile unit tests.
+# Note that a separating `--` is necessary if `--unit-test` is the last flag.
+cargo flamegraph --unit-test -- test::in::package::with::single::crate
+cargo flamegraph --unit-test crate_name -- test::in::package::with::multiple:crate
+cargo flamegraph --unit-test --dev test::may::omit::separator::if::unit::test::flag::not::last::flag
 ```
 
 ## Usage
@@ -87,19 +93,44 @@ cargo flamegraph --example some_example --features some_features
 
 ```
 USAGE:
-    cargo flamegraph [FLAGS] [OPTIONS] -- [[ARGS_FOR_YOUR_BINARY]]
+    cargo-flamegraph flamegraph [FLAGS] [OPTIONS] [trailing-arguments]...
 
 FLAGS:
-    -h, --help       Prints help information
-    -r, --release    Activate release mode
-    -V, --version    Prints version information
+        --deterministic          Colors are selected such that the color of a function does not change between runs
+        --dev                    Build with the dev profile
+    -h, --help                   Prints help information
+    -i, --inverted               Plot the flame graph up-side-down
+        --no-default-features    Disable default features
+        --open                   Open the output .svg file with default program
+        --reverse                Generate stack-reversed flame graph
+        --root                   Run with root privileges (using `sudo`)
+        --no-inline              Disable inlining for perf script because of performance issues
+    -V, --version                Prints version information
+    -v, --verbose                Print extra output to help debug problems
 
 OPTIONS:
-    -b, --bin <bin>              Binary to run
-    --bench <bench>              Benchmark to run
-    --example <example>          Example to run
-    -f, --features <features>    Build features to enable
-    -o, --output <output>        Output file, flamegraph.svg if not present
+        --bench <bench>                    Benchmark to run
+    -b, --bin <bin>                        Binary to run
+    -c, --cmd <custom-cmd>                 Custom command for invoking perf/dtrace
+        --example <example>                Example to run
+    -f, --features <features>              Build features to enable
+    -F, --freq <frequency>                 Sampling frequency
+        --image-width <image-width>        Image width in pixels
+        --manifest-path <manifest-path>    Path to Cargo.toml
+        --min-width <FLOAT>                Omit functions smaller than <FLOAT> pixels [default: 0.01]
+        --notes <STRING>                   Set embedded notes in SVG
+    -o, --output <output>                  Output file, flamegraph.svg if not present
+    -p, --package <package>                package with the binary to run
+        --palette <palette>                Color palette [possible values: hot, mem, io, red, green, blue, aqua, yellow,
+                                           purple, orange, wakeup, java, perl, js, rust]
+        --test <test>                      Test binary to run (currently profiles the test harness and all tests in the
+                                           binary)
+        --unit-test <unit-test>            Crate target to unit test, <unit-test> may be omitted if crate only has one
+                                           target (currently profiles the test harness and all tests in the binary; test
+                                           selection can be passed as trailing arguments after `--` as separator)
+
+ARGS:
+    <trailing-arguments>...    Trailing arguments are passed to the binary being profiled
 ```
 
 Then open the resulting `flamegraph.svg` with a browser, because most image

--- a/src/bin/cargo-flamegraph.rs
+++ b/src/bin/cargo-flamegraph.rs
@@ -87,6 +87,7 @@ struct Opt {
     #[structopt(flatten)]
     graph: flamegraph::Options,
 
+    /// Trailing arguments are passed to the binary being profiled.
     trailing_arguments: Vec<String>,
 }
 

--- a/src/bin/cargo-flamegraph.rs
+++ b/src/bin/cargo-flamegraph.rs
@@ -237,9 +237,10 @@ fn workload(opt: &Opt, artifacts: &[Artifact]) -> anyhow::Result<Vec<String>> {
 
     const NONE: u32 = 0;
     if !opt.dev && debug_level.unwrap_or(NONE) == NONE {
-        let profile = match opt.bench {
-            Some(_) => "bench",
-            None => "release",
+        let profile = match opt.example.as_ref().or_else(|| opt.bin.as_ref()) {
+            Some(_) => "release",
+            // tests use the bench profile in release mode.
+            _ => "bench",
         };
 
         eprintln!("\nWARNING: profiling without debuginfo. Enable symbol information by adding the following lines to Cargo.toml:\n");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,9 +216,6 @@ fn terminated_by_error(status: ExitStatus) -> bool {
     !status.success()
 }
 
-// False positive in clippy for non-exhaustive struct FlamegraphOptions:
-// https://github.com/rust-lang/rust-clippy/issues/6559
-#[allow(clippy::field_reassign_with_default)]
 pub fn generate_flamegraph_for_workload(
     workload: Workload,
     mut opts: Options,


### PR DESCRIPTION
## About
This PR adds a feature to `cargo flamegraph`. It adds a flag `--unit-test` to the available command line options which profiles a unit test executable. The previous version only allowed profiling of integration tests. The flag is mutually exclusive to all other profiling target selection options (i.e. `--bin`, `--bench`, `--test`, `--example`). It takes an optional value that specifies the target that should be unit-tested. The target is required if the package has multiple targets.

## Relevant issue:
- #139 

## Known issues/limitations:
### Unit test selection often requires -- as separator
Whenever the new flag is passed as the last flag, it is necessary to separate the following test selection like so:
`cargo flamegraph --unit-test -- test::name`
The reason behind this is that `--unit-test` takes an optional argument. `clap` tries to consume the test selection arguments as values for `--unit-test` instead. This leads to either a parse error or an error when trying to find the test selection as target.

This could be prevented by removing the optional argument to `--unit-test` and adding another flag `--unit-test-target <target_name>` but I'm not convinced that this improves the overall situation. Another solution might be to redesign the command line interface entirely and split it into subcommands:
```
cargo flamegraph bin
cargo flamegraph --dev test integration_test
cargo flamegraph --no-inline --package package1 unittest --target target_name test::name
```
This, however, seems to be too big of a change as it would be quite drastic and a breaking change.

### `test --no-run` should be used instead of `build --tests` (Obsolete, fixed in commit 80e47f4b64f5bf189d62e002edd8091f1826f04c)
Currently, the code invokes `cargo build --tests` to build the unit test executable before profiling. This leads to two issues:
1. It builds most tests (by default all unit and integration tests) leading to increased compile times and unrelated compiler errors blocking the profiling.
2. If the user has `test = false` for a target, it **does not** build the test executable, which means we cannot profile it.

Both issues can be resolved by using `cargo test --no-run --lib` or `cargo test --no-run --bin bname` to compile the test executable. But it requires knowing whether we are testing a lib or a binary and in the binary case the name is needed as well.
Therefore I decided not to implement it yet. I plan to tackle this issue after a second PR that changes `cargo flamegraph` to parse JSON output of the build commands instead of searching for the binary by name (created by now: #141).

### Wrong target binary selection (Obsolete, fixed with merge of  #141)
Using the current approach of searching for the binary by name, it is impossible to tell if we have found the unit test binary or the actual binary:
```
$ cargo build --release; cargo build --release --tests
$ ls target/release/deps
main1-7d658e30325341e3 main1-65b88a055fb7b8c6
```
Simply taking the binary with the newest timestamp can alleviate the situation in most cases. But to make it foolproof, it's necessary to read the output of cargo build. Therefore choosing by timestamp is not implemented as well. The aforementioned second PR will deal with this issue.