### PR TITLE
Run cargo build and read JSON output

### DIFF
--- a/src/bin/cargo-flamegraph.rs
+++ b/src/bin/cargo-flamegraph.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use cargo_metadata::{Artifact, Message, MetadataCommand};
+use cargo_metadata::{Artifact, Message, MetadataCommand, Package};
 use structopt::StructOpt;
 
 use flamegraph::Workload;
@@ -281,17 +281,33 @@ fn workload(opt: &Opt, artifacts: &[Artifact]) -> Vec<String> {
     result
 }
 
-fn find_unique_bin_target() -> String {
-    let mut bin_targets: Vec<String> = MetadataCommand::new()
+#[derive(Clone, Debug)]
+struct BinaryTarget {
+    package: String,
+    target: String,
+}
+
+impl std::fmt::Display for BinaryTarget {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "target {} in package {}", self.target, self.package)
+    }
+}
+
+fn find_unique_bin_target() -> BinaryTarget {
+    let mut bin_targets: Vec<BinaryTarget> = MetadataCommand::new()
         .no_deps()
         .exec()
         .expect("failed to access crate metadata")
         .packages
         .into_iter()
         .flat_map(|p| {
-            p.targets
-                .into_iter()
-                .filter_map(|t| t.kind.contains(&"bin".into()).then(|| t.name))
+            let Package { targets, name, .. } = p;
+            targets.into_iter().filter_map(move |t| {
+                t.kind.contains(&"bin".into()).then(|| BinaryTarget {
+                    package: name.clone(),
+                    target: t.name,
+                })
+            })
         })
         .collect();
 
@@ -323,7 +339,9 @@ fn main() {
     let Opts::Flamegraph(mut opt) = Opts::from_args();
 
     if !opt.has_explicit_target() {
-        opt.bin = find_unique_bin_target().into();
+        let BinaryTarget { target, package } = find_unique_bin_target();
+        opt.bin = target.into();
+        opt.package = package.into();
     }
 
     let artifacts = build(&opt);


### PR DESCRIPTION
## About
This PR changes `cargo flamegraph` so that it reads the output of `cargo build` to determine the patch of the binary that should be profiled.
Because of this change the automatic target selection had to be redone as previously it just chose the only binary from the target folder. Now, we run `cargo metadata`, find the only binary target of the workspace first and pass this target explictly. If there are multiple or no binary targets, we abort with an error.
I tested the new version several different dummy crates and workspaces as well as `ripgrep`. It seems to work fine.

## Relevant issue
- #139 This is where the idea came up.
- #132  This should be fixed by this PR assuming `cargo build` tells us the correct binary.
- #79 This should also be fixed.

## Follow-up PR
- #142 

