### PR TITLE
Combine #140 and #141, fix merge conflicts and add improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ cargo flamegraph -c "record -e branch-misses -c 100 --call-graph lbr -g"
 cargo flamegraph --bench some_benchmark --features some_features -- --bench`
 
 cargo flamegraph --example some_example --features some_features
+
+# Profile unit tests.
+# Note that a separating `--` is necessary if `--unit-test` is the last flag.
+cargo flamegraph --unit-test -- test::in::package::with::single::crate
+cargo flamegraph --unit-test crate_name -- test::in::package::with::multiple:crate
+cargo flamegraph --unit-test --dev test::may::omit::separator::if::unit::test::flag::not::last::flag
 ```
 
 ## Usage
@@ -77,19 +83,44 @@ cargo flamegraph --example some_example --features some_features
 
 ```
 USAGE:
-    cargo flamegraph [FLAGS] [OPTIONS] -- [[ARGS_FOR_YOUR_BINARY]]
+    cargo-flamegraph flamegraph [FLAGS] [OPTIONS] [trailing-arguments]...
 
 FLAGS:
-    -h, --help       Prints help information
-    -r, --release    Activate release mode
-    -V, --version    Prints version information
+        --deterministic          Colors are selected such that the color of a function does not change between runs
+        --dev                    Build with the dev profile
+    -h, --help                   Prints help information
+    -i, --inverted               Plot the flame graph up-side-down
+        --no-default-features    Disable default features
+        --open                   Open the output .svg file with default program
+        --reverse                Generate stack-reversed flame graph
+        --root                   Run with root privileges (using `sudo`)
+        --no-inline              Disable inlining for perf script because of performace issues
+    -V, --version                Prints version information
+    -v, --verbose                Print extra output to help debug problems
 
 OPTIONS:
-    -b, --bin <bin>              Binary to run
-    --bench <bench>              Benchmark to run
-    --example <example>          Example to run
-    -f, --features <features>    Build features to enable
-    -o, --output <output>        Output file, flamegraph.svg if not present
+        --bench <bench>                    Benchmark to run
+    -b, --bin <bin>                        Binary to run
+    -c, --cmd <custom-cmd>                 Custom command for invoking perf/dtrace
+        --example <example>                Example to run
+    -f, --features <features>              Build features to enable
+    -F, --freq <frequency>                 Sampling frequency
+        --image-width <image-width>        Image width in pixels
+        --manifest-path <manifest-path>    Path to Cargo.toml
+        --min-width <FLOAT>                Omit functions smaller than <FLOAT> pixels [default: 0.1]
+        --notes <STRING>                   Set embedded notes in SVG
+    -o, --output <output>                  Output file, flamegraph.svg if not present
+    -p, --package <package>                package with the binary to run
+        --palette <palette>                Color palette [possible values: hot, mem, io, red, green, blue, aqua, yellow,
+                                           purple, orange, wakeup, java, perl, js, rust]
+        --test <test>                      Test binary to run (currently profiles the test harness and all tests in the
+                                           binary)
+        --unit-test <unit-test>            Crate target to unit test, <unit-test> may be omitted if crate only has one
+                                           target (currently profiles the test harness and all tests in the binary; test
+                                           selection can be passed as trailing arguments after `--` as separator)
+
+ARGS:
+    <trailing-arguments>...    
 ```
 
 Then open the resulting `flamegraph.svg` with a browser, because most image

--- a/src/bin/cargo-flamegraph.rs
+++ b/src/bin/cargo-flamegraph.rs
@@ -258,6 +258,11 @@ fn check_debug_info(opt: &Opt, artifact: &Artifact) {
         );
         eprintln!("[profile.{}]", profile);
         eprintln!("debug = true\n");
+        eprintln!("Or set this environment variable:\n");
+        eprintln!(
+            "CARGO_PROFILE_{}_DEBUG=true\n",
+            profile.to_uppercase()
+        );
     }
 }
 
@@ -331,7 +336,13 @@ fn find_unique_bin_target() -> String {
         .collect();
 
     match bin_targets.as_slice() {
-        [target] => target.clone(),
+        [target] => {
+            eprintln!(
+                "automatically selected {} as it is the only binary target",
+                target
+            );
+            target.clone()
+        }
         [] => {
             eprintln!(
                 "crate has no binary targets: try passing \

--- a/src/bin/cargo-flamegraph.rs
+++ b/src/bin/cargo-flamegraph.rs
@@ -116,6 +116,30 @@ impl Opt {
             || self.example.is_some()
             || self.test.is_some()
     }
+
+    fn target_kind(&self) -> &'static str {
+        match self {
+            Opt { bin: Some(_), .. } => "bin",
+            Opt {
+                example: Some(_), ..
+            } => "example",
+            Opt { test: Some(_), .. } => "test",
+            Opt { bench: Some(_), .. } => "bench",
+            _ => panic!("No target for profiling."),
+        }
+    }
+
+    fn target_name(&self) -> &str {
+        match self {
+            Opt { bin: Some(t), .. } => &t,
+            Opt {
+                example: Some(t), ..
+            } => &t,
+            Opt { test: Some(t), .. } => &t,
+            Opt { bench: Some(t), .. } => &t,
+            _ => panic!("No target for profiling."),
+        }
+    }
 }
 
 #[derive(Debug, StructOpt)]
@@ -247,17 +271,8 @@ fn select_executable(
     opt: &Opt,
     artifacts: &[Artifact],
 ) -> PathBuf {
-    let (target, kind) = match opt {
-        Opt { bin: Some(t), .. } => (t, "bin".to_owned()),
-        Opt {
-            example: Some(t), ..
-        } => (t, "example".to_owned()),
-        Opt { test: Some(t), .. } => (t, "test".to_owned()),
-        Opt { bench: Some(t), .. } => {
-            (t, "bench".to_owned())
-        }
-        _ => unimplemented!(),
-    };
+    let target = opt.target_name();
+    let kind = opt.target_kind().to_owned();
 
     if artifacts.iter().all(|a| a.executable.is_none()) {
         eprintln!( "build artifacts do not contain any executable to profile");

--- a/src/bin/cargo-flamegraph.rs
+++ b/src/bin/cargo-flamegraph.rs
@@ -246,6 +246,9 @@ fn build(opt: BuildOpts) -> Vec<Artifact> {
             cmd.args(&["build", "--test", name]);
         }
         TargetKind::UnitTest => {
+            // `cargo test` is required because `cargo build` does not
+            // have flags to build individual unit test targets.
+            // `cargo test` requires differentiating between lib and bin.
             if opt.target.kind.contains(&"lib".to_owned()) {
                 cmd.args(&["test", "--no-run", "--lib"]);
             } else {

--- a/src/bin/cargo-flamegraph.rs
+++ b/src/bin/cargo-flamegraph.rs
@@ -131,12 +131,12 @@ impl Opt {
 
     fn target_name(&self) -> &str {
         match self {
-            Opt { bin: Some(t), .. } => &t,
+            Opt { bin: Some(t), .. } => t,
             Opt {
                 example: Some(t), ..
-            } => &t,
-            Opt { test: Some(t), .. } => &t,
-            Opt { bench: Some(t), .. } => &t,
+            } => t,
+            Opt { test: Some(t), .. } => t,
+            Opt { bench: Some(t), .. } => t,
             _ => panic!("No target for profiling."),
         }
     }
@@ -282,7 +282,7 @@ fn select_executable(
     // target.kind is an array for some reason. No idea why though, it always seems to contain exactly one element.
     // If you know why, feel free to PR and handle kind properly.
     let artifact = artifacts.iter().find(|a| {
-        &a.target.name == target
+        a.target.name == target
             && a.target.kind.contains(&kind)
             && a.executable.is_some()
     });

--- a/src/bin/cargo-flamegraph.rs
+++ b/src/bin/cargo-flamegraph.rs
@@ -153,7 +153,7 @@ enum Opts {
 }
 
 fn build(opt: &Opt) -> Vec<Artifact> {
-    use std::process::{Command, Output};
+    use std::process::{Command, Output, Stdio};
     let mut cmd = Command::new("cargo");
 
     // This will build benchmarks with the `bench` profile. This is needed
@@ -208,17 +208,14 @@ fn build(opt: &Opt) -> Vec<Artifact> {
         cmd.arg("--no-default-features");
     }
 
-    cmd.arg("--message-format=json");
+    cmd.arg("--message-format=json-render-diagnostics");
 
     if opt.verbose {
         println!("build command: {:?}", cmd);
     }
 
-    let Output {
-        status,
-        stdout,
-        stderr,
-    } = cmd
+    let Output { status, stdout, .. } = cmd
+        .stderr(Stdio::inherit())
         .output()
         .expect("failed to execute cargo build command");
 
@@ -236,10 +233,7 @@ fn build(opt: &Opt) -> Vec<Artifact> {
         .collect();
 
     if !status.success() {
-        eprintln!(
-            "cargo build failed: {}",
-            String::from_utf8_lossy(&stderr)
-        );
+        eprintln!("cargo build failed!");
         std::process::exit(1);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -239,9 +239,6 @@ fn terminated_by_error(status: ExitStatus) -> bool {
     !status.success()
 }
 
-// False positive in clippy for non-exhaustive struct FlamegraphOptions:
-// https://github.com/rust-lang/rust-clippy/issues/6559
-#[allow(clippy::field_reassign_with_default)]
 pub fn generate_flamegraph_for_workload<
     P: AsRef<std::path::Path>,
 >(


### PR DESCRIPTION
## About

This PR contains the contents of #140 and #141 merged together into one PR with all the merge conflicts resolved. In addition, it addresses the following issues from #140:
- `test --no-run` should be used instead of `build --tests`; for this I also took the liberty to refactor the build method a bit.
- Wrong target binary selection; pretty much fixed itself by having #141 in the branch.

 I tested the new version with several different dummy crates and workspaces as well as ripgrep. It seems to work fine. (My tests only entailed `cargo-flamegraph` itself though, not the machinery behind it that is required to generate a (correct) flamegraph.)