### PR TITLE
add shell completion for flamegraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,16 @@ This will make the `flamegraph` and
 binary directory. On most systems this is
 usually something like `~/.cargo/bin`.
 
+## Shell auto-completion
+
+At the moment, only `flamegraph` supports auto-completion. Supported shells are `bash`, `fish`, `zsh`, `powershell` and `elvish`.
+`cargo-flamegraph` does not support auto-completion because it is not as straight-forward to implement for custom cargo subcommands. See #153 for details.
+
+How you enable auto-completion depends on your shell, e.g.
+```bash
+flamegraph --completions bash > $XDG_CONFIG_HOME/bash_completion # or /etc/bash_completion.d/
+```
+
 ## Examples
 
 ```

--- a/src/bin/flamegraph.rs
+++ b/src/bin/flamegraph.rs
@@ -12,6 +12,10 @@ struct Opt {
     #[structopt(short = "p", long = "pid")]
     pid: Option<u32>,
 
+    /// Generate shell completions for the given shell.
+    #[structopt(long = "completions")]
+    completions: Option<structopt::clap::Shell>,
+
     #[structopt(flatten)]
     graph: flamegraph::Options,
 
@@ -20,6 +24,12 @@ struct Opt {
 
 fn main() -> anyhow::Result<()> {
     let opt = Opt::from_args();
+
+    if let Some(shell) = opt.completions {
+        Opt::clap().gen_completions_to("flamegraph", shell, &mut std::io::stdout().lock());
+        return Ok(());
+    }
+
     let workload = match (opt.pid, opt.trailing_arguments.is_empty()) {
         (Some(p), true) => Workload::Pid(p),
         (None, false) => Workload::Command(opt.trailing_arguments.clone()),


### PR DESCRIPTION
## About
This PR adds shell auto-completion support for the `flamegraph` binary. `flamegraph --completions <shell>` prints the completion script for the given shell to stdout. Currently supported shells are `bash`, `fish`, `powershell` and`elvish` (and `zsh` but it does not work).

Internally, `clap`s  [completion generation](https://docs.rs/clap/2.33.3/clap/struct.App.html#method.gen_completions_to) is used. 

## Known issues/limitations:
### Completions must be installed manually.

`cargo install` does not support installing extra files right now if `clap`s [documentation](https://docs.rs/clap/2.33.3/clap/struct.App.html#method.gen_completions_to) is to be believed. This means we cannot place a completion script into a completion directory for the user on install and would have to provide a distribution package (`deb`, `rpm`, ...) for this.

###  No completions for `cargo flamegraph`.

As far as I know, there is no official way to get completions for [custom cargo subcommands](https://doc.rust-lang.org/cargo/reference/external-tools.html#custom-subcommands). I tried getting it to work anyway without success. The issue is that you have to provide a binary name for which the completions will be generated. `cargo-flamegraph` sort of works for this if you invoke it directly but does not work at all when using `cargo flamegraph` as a custom subcommand. `cargo` as the binary name seems to be working great for `cargo flamegraph`. However it overrides existing completions so that you lose completions for `cargo build` etc.

### Invoking `flamegraph --completions zsh` panics.

I didn't look into this.  `clap` panics:
```
thread 'main' panicked at 'Fatal internal error. Please consider filing a bug report at https://github.com/clap-rs/clap/issues', ~/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-2.33.3/src/completions/zsh.rs:346:29
stack backtrace:
   0: rust_begin_unwind
             at /rustc/a178d0322ce20e33eac124758e837cbd80a6f633/library/std/src/panicking.rs:515:5
   1: core::panicking::panic_fmt
             at /rustc/a178d0322ce20e33eac124758e837cbd80a6f633/library/core/src/panicking.rs:92:14
   2: core::option::expect_failed
             at /rustc/a178d0322ce20e33eac124758e837cbd80a6f633/library/core/src/option.rs:1243:5
   3: core::option::Option<T>::expect
             at /rustc/a178d0322ce20e33eac124758e837cbd80a6f633/library/core/src/option.rs:351:21
   4: clap::completions::zsh::write_opts_of
             at ~/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-2.33.3/src/completions/zsh.rs:346:29
   5: clap::completions::zsh::get_args_of
             at ~/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-2.33.3/src/completions/zsh.rs:284:16
   6: clap::completions::zsh::ZshGen::generate_to
             at ~/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-2.33.3/src/completions/zsh.rs:56:32
   7: clap::completions::ComplGen::generate
             at ~/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-2.33.3/src/completions/mod.rs:38:27
   8: clap::app::parser::Parser::gen_completions_to
             at ~/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-2.33.3/src/app/parser.rs:121:9
   9: clap::app::App::gen_completions_to
             at ~/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-2.33.3/src/app/mod.rs:1442:9
  10: flamegraph::main
```