### PR TITLE
fix #31: mention macOS status explicitely

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,15 @@ be acceptable for your security needs etc...
 echo -1 | sudo tee /proc/sys/kernel/perf_event_paranoid
 ```
 
+### DTrace on macOS
+
+On macOS, there is no alternative to running as superuser in order to
+enable dtrace. The simplest way is to use `--root`, this way `rustc`
+will be run normally but the binary will get run as superuser.
+
+Be aware that if the binary being tested is user-aware, this does
+change its behaviour.
+
 ## Improving output when running with `--release`
 
 Due to optimizations etc... sometimes the quality


### PR DESCRIPTION
Disabling System Integrity Protection only seems necessary to
trace *system utilities*: binaries living in `/System`, `/usr` (except
`/usr/local`), `/bin`, `/sbin`, `/var`, and preinstalled applications.

Therefore tracing a rust utility probably should not conflict with
SIP, but it still requires running a superuser.