### PR TITLE
fix: permission denied reading stacks file

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,8 +186,8 @@ mod arch {
 
         // Ensure the file is readable by the current user if dtrace was run
         // with sudo.
-        #[cfg(unix)]
         if sudo {
+            #[cfg(unix)]
             if let Ok(user) = env::var("USER") {
                 Command::new("sudo")
                     .args(["chown", user.as_str(), "cargo-flamegraph.stacks"])

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,8 +118,8 @@ mod arch {
 mod arch {
     use super::*;
 
-    pub const SPAWN_ERROR: &'static str = "could not spawn dtrace";
-    pub const WAIT_ERROR: &'static str = "unable to wait for dtrace child command to exit";
+    pub const SPAWN_ERROR: &str = "could not spawn dtrace";
+    pub const WAIT_ERROR: &str = "unable to wait for dtrace child command to exit";
 
     pub(crate) fn initial_command(
         workload: Workload,


### PR DESCRIPTION
Ensures the `cargo-flamegraph.stacks` file generated when using the dtrace profiler can be read to be collapsed by setting the owner to `$USER` instead of `root` 👍 

Fixes #173.

---

* fix: set cargo-flamegraph.stacks file owner (ae0f5d9)

      This commit adds code to execute:

      	sudo chown $USER cargo-flamegraph.stacks

      When the following conditions are met:

      	* The flamegraph was generated with dtrace (aka. not on Linux)
      	* The user passed --root on the command line
      	* The USER env is set

      This ensures the cargo-flamegraph.stacks file wrote by dtrace as "root" is
      readable by the non-root user.

* refactor: fix clippy lint (e9164ca)

      Removes redundant 'static on const vars.

