### PR TITLE
Fix #180: Handle workspaces more similar to `cargo build/run/test`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,9 +227,9 @@ dependencies = [
 
 [[package]]
 name = "inferno"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5e0d042b82d2153d831ad6f4b865ddb06d9941a086eb9974f8f58cf0368b6e3"
+checksum = "0fe3ba15e9cce341de198353aebd07d8009d211fb5556920bd4bdd3bb79fafd7"
 dependencies = [
  "ahash",
  "atty",


### PR DESCRIPTION
## About
This PR fixes the reproducible issues mentioned in #180. Namely this is the different behavior between standard cargo commands and `cargo flamegraph` when using workspaces. The default cargo commands by default only take into account crates in the working directory while `cargo flamegraph` was working on the entire working space.

The PR tries to amend that by changing `cargo flamegraph` behavior in the following ways:
- `cargo flamegraph` chooses a target only from the current working directory unless `--package` or `--manifest-path` are used (instead of the entire workspace).
- `cargo flamegraph` suggests targets only from the current working directory unless `--package` or `--manifest-path` are used (instead of the entire workspace).

I tested the new version with several different dummy crates and workspaces as well as ripgrep. It seems to work fine and just like the standard cargo commands.

## Breaking changes (Not sure if this is relevant for anyone though.)
As described above, `cargo flamegraph` no longer works on an entire workspace but only on the crate in the current working directory. This means that calling `cargo flamegraph` in a crate within a workspace tries to execute the binary within this crate instead of the workspace binary.

Example: calling `cargo flamegraph` in `ripgrep/crates/printer` (a library crate) now errors because it cannot find a binary instead of executing `rg` (the workspace executable).

## Relevant issues
- #180

