### PR TITLE
Document --skip-after, update inferno (skip_after changed)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,12 +166,13 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "4.0.2"
+version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e77a43b28d0668df09411cb0bc9a8c2adc40f9a048afe863e05fd43251e8e39c"
+checksum = "c0834a35a3fce649144119e18da2a4d8ed12ef3862f47183fd46f625d072d96c"
 dependencies = [
  "cfg-if",
  "num_cpus",
+ "parking_lot",
 ]
 
 [[package]]
@@ -234,9 +235,9 @@ dependencies = [
 
 [[package]]
 name = "inferno"
-version = "0.10.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fe3ba15e9cce341de198353aebd07d8009d211fb5556920bd4bdd3bb79fafd7"
+checksum = "26143de514661e4241e71840e4f82029b5d8b55e57b25be63b5126869794df57"
 dependencies = [
  "ahash",
  "atty",
@@ -244,7 +245,7 @@ dependencies = [
  "crossbeam-utils",
  "dashmap",
  "indexmap",
- "itoa",
+ "itoa 1.0.1",
  "lazy_static",
  "log",
  "num-format",
@@ -261,6 +262,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
+name = "itoa"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -271,6 +278,15 @@ name = "libc"
 version = "0.2.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e167738f1866a7ec625567bae89ca0d44477232a4f7c52b1c7f2adc2c98804f"
+
+[[package]]
+name = "lock_api"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -300,14 +316,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bafe4179722c2894288ee77a9f044f02811c86af699344c498b0840c698a2465"
 dependencies = [
  "arrayvec",
- "itoa",
+ "itoa 0.4.8",
 ]
 
 [[package]]
 name = "num_cpus"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -336,6 +352,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28141e0cc4143da2443301914478dc976a61ffdb3f043058310c70df2fed8954"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-sys",
 ]
 
 [[package]]
@@ -390,6 +429,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8380fe0152551244f0747b1bf41737e0f8a74f97a14ccefd1148187271634f3c"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -409,6 +457,12 @@ name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "semver"
@@ -445,7 +499,7 @@ version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0ffa0837f2dfa6fb90868c2b5468cad482e175f7dad97e7421951e663f2b527"
 dependencies = [
- "itoa",
+ "itoa 0.4.8",
  "ryu",
  "serde",
 ]
@@ -468,6 +522,12 @@ checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
 name = "str_stack"
@@ -561,3 +621,46 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3df6e476185f92a12c072be4a189a0210dcdcf512a1891d6dff9edb874deadc6"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8e92753b1c443191654ec532f14c199742964a061be25d77d7a96f09db20bf5"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a711c68811799e017b6038e0922cb27a5e2f43a2ddb609fe0b6f3eeda9de615"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c11bb1a02615db74680b32a68e2d61f553cc24c4eb5b4ca10311740e44172"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c912b12f7454c6620635bbff3450962753834be2a594819bd5e945af18ec64bc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "504a2476202769977a040c6364301a3f65d0cc9e3fb08600b2bda150a0488316"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ anyhow = "1.0.43"
 cargo_metadata = "0.14.0"
 clap = { version = "3.0", features = ["derive"] }
 clap_complete = "3.0"
-inferno = { version = "0.10.8", default_features = false, features = ["multithreaded", "nameattr"] }
+inferno = { version = "0.11.0", default_features = false, features = ["multithreaded", "nameattr"] }
 opener = "0.5.0"
 
 [target.'cfg(unix)'.dependencies]

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ OPTIONS:
     -p, --package <package>                package with the binary to run
         --palette <palette>                Color palette [possible values: hot, mem, io, red, green, blue, aqua, yellow,
                                            purple, orange, wakeup, java, perl, js, rust]
-        --skip-after <skip-after>          
+        --skip-after <STRING>              Cut off stack frames below the named function [linux only]
         --test <test>                      Test binary to run (currently profiles the test harness and all tests in the
                                            binary)
         --unit-test <unit-test>            Crate target to unit test, <unit-test> may be omitted if crate only has one

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ OPTIONS:
     -p, --package <package>                package with the binary to run
         --palette <palette>                Color palette [possible values: hot, mem, io, red, green, blue, aqua, yellow,
                                            purple, orange, wakeup, java, perl, js, rust]
-        --skip-after <STRING>              Cut off stack frames below the named function [linux only]
+        --skip-after <FUNCTION>            Cut off stack frames below <FUNCTION>; may be repeated [linux only]
         --test <test>                      Test binary to run (currently profiles the test harness and all tests in the
                                            binary)
         --unit-test <unit-test>            Crate target to unit test, <unit-test> may be omitted if crate only has one

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -293,9 +293,7 @@ pub fn generate_flamegraph_for_workload(workload: Workload, opts: Options) -> an
 
     #[cfg(target_os = "linux")]
     {
-        if let Some(skip_after) = &opts.flamegraph_options.skip_after {
-            collapse_options.skip_after = Some(skip_after.into())
-        }
+        collapse_options.skip_after = opts.flamegraph_options.skip_after.clone();
     }
 
     Folder::from(collapse_options)
@@ -412,10 +410,10 @@ pub struct FlamegraphOptions {
     )]
     pub palette: Option<Palette>,
 
-    /// Cut off stack frames below the named function
+    /// Cut off stack frames below <FUNCTION>; may be repeated
     #[cfg(target_os = "linux")]
-    #[clap(long, value_name = "STRING")]
-    pub skip_after: Option<String>,
+    #[clap(long, value_name = "FUNCTION")]
+    pub skip_after: Vec<String>,
 
     /// Produce a flame chart (sort by time, do not merge stacks)
     #[clap(long = "flamechart", conflicts_with = "reverse")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -412,8 +412,9 @@ pub struct FlamegraphOptions {
     )]
     pub palette: Option<Palette>,
 
+    /// Cut off stack frames below the named function
     #[cfg(target_os = "linux")]
-    #[clap(long)]
+    #[clap(long, value_name = "STRING")]
     pub skip_after: Option<String>,
 
     /// Produce a flame chart (sort by time, do not merge stacks)


### PR DESCRIPTION
See: https://github.com/jonhoo/inferno/pull/231

We also should bump the version to 0.6.0 because the FlamegraphOptions is public, so this is a breaking change. Not sure if anyone is using this API, though. I did not include a version bump in this PR.