### PR TITLE
Copy more stack by default.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ mod arch {
         };
 
         let args = custom_cmd.unwrap_or(format!(
-            "record -F {} --call-graph dwarf -g",
+            "record -F {} --call-graph dwarf,16384 -g",
             freq.unwrap_or(997)
         ));
 


### PR DESCRIPTION
`perf record --call-graph dwarf` defaults to copying 8192 bytes of stack
on every sample. These bytes are stored in the perf.data file and then
used for dwarf-based stack unwinding when `perf script` is called.

This patch makes us ask perf to use 16384 bytes, twice the default.
This will roughly double the size of the perf.data file, but it should
lead to less confusing flame graphs.

With the default value, only 5% of the samples in a Rust project I tested
(mozilla/dump_syms) were able to unwind successfully. The remaining
samples had incomplete stacks due to insufficient stack bytes.
With the value 16384, that percentage rose to 70%.
This project didn't have particularly deep stacks to begin with.
It's probably easy to find other applications where an even higher value
is needed. We can increase the value later once we run into those cases.

Incomplete stacks cause very awkward-looking flame graphs. It's worth
going through some pain to get complete stacks: Only complete stacks can
be properly rooted and merged with other stacks in the graph. Unrooted
stacks get awkwardly stashed to the side and generally don't make much
visual sense.