### PR TITLE
Fix examples for arbitrary process

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,13 +68,13 @@ flamegraph --completions bash > $XDG_CONFIG_HOME/bash_completion # or /etc/bash_
 
 ```
 # if you'd like to profile an arbitrary executable:
-flamegraph [-o my_flamegraph.svg] /path/to/my/binary --my-arg 5
+flamegraph [-o my_flamegraph.svg] -- /path/to/my/binary --my-arg 5
 
 # NOTE: By default, perf tries to compute which functions are
 # inlined at every stack frame for every sample. This can take
 # a very long time (see https://github.com/flamegraph-rs/flamegraph/issues/74).
 # If you don't want this, you can pass --no-inline to flamegraph:
-flamegraph --no-inline [-o my_flamegraph.svg] /path/to/my/binary --my-arg 5
+flamegraph --no-inline [-o my_flamegraph.svg] -- /path/to/my/binary --my-arg 5
 
 # cargo support provided through the cargo-flamegraph binary!
 # defaults to profiling cargo run --release


### PR DESCRIPTION
The examples for arbitrary processes seems wrong. At least I had to change them to make them work.