### PR TITLE
Add --test example to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ cargo flamegraph --example some_example --features some_features
 cargo flamegraph --unit-test -- test::in::package::with::single::crate
 cargo flamegraph --unit-test crate_name -- test::in::package::with::multiple:crate
 cargo flamegraph --unit-test --dev test::may::omit::separator::if::unit::test::flag::not::last::flag
+
+# Profile integration tests.
+cargo flamegraph --test test_name
 ```
 
 ## Usage


### PR DESCRIPTION
I was struggling with figuring out how to run an integration test with flamegraph for a bit. I think adding an example for it to the readme makes it clearer that --unit-test and --test are separate and I suppose that would have helped me.