### PR TITLE
Add documentation about `--pid` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ flamegraph --completions bash > $XDG_CONFIG_HOME/bash_completion # or /etc/bash_
 # if you'd like to profile an arbitrary executable:
 flamegraph [-o my_flamegraph.svg] /path/to/my/binary --my-arg 5
 
+# or if the executable is already running, you can provide the PID via `-p` (or `--pid`) flag:
+flamegraph [-o my_flamegraph.svg] --pid 1337
+
 # NOTE: By default, perf tries to compute which functions are
 # inlined at every stack frame for every sample. This can take
 # a very long time (see https://github.com/flamegraph-rs/flamegraph/issues/74).


### PR DESCRIPTION
Quite a useful feature, even wanted by some, turns out exists all along!

Just not documented, so adding it here.

~Fixes #22  (kinda?)~ (actually no, that one also talks about a timeout value)