### PR TITLE
Add --post-process feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,6 +206,7 @@ dependencies = [
  "clap_complete",
  "inferno",
  "opener",
+ "shlex",
  "signal-hook",
 ]
 
@@ -515,6 +516,12 @@ dependencies = [
  "ryu",
  "serde",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "signal-hook"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ clap = { version = "3.0", features = ["derive"] }
 clap_complete = "3.0"
 inferno = { version = "0.11.0", default_features = false, features = ["multithreaded", "nameattr"] }
 opener = "0.5.0"
+shlex = "1.1.0"
 
 [target.'cfg(unix)'.dependencies]
 signal-hook = "0.3.10"

--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ OPTIONS:
     -p, --package <package>                package with the binary to run
         --palette <palette>                Color palette [possible values: hot, mem, io, red, green, blue, aqua, yellow,
                                            purple, orange, wakeup, java, perl, js, rust]
+        --post-process                     Run a command to process the folded stacks, taking the input from stdin 
+                                           and outputting to stdout.
         --skip-after <FUNCTION>            Cut off stack frames below <FUNCTION>; may be repeated [linux only]
         --test <test>                      Test binary to run (currently profiles the test harness and all tests in the
                                            binary)


### PR DESCRIPTION
Implementation of the feature suggested in #214.

I decided to provide the command as a string and split it into arguments using [shlex](https://crates.io/crates/shlex). A problem with this is, that shlex splits the string, mimicking a POSIX shell. I don't know enough about windows to know if that could be an issue.

The difficulty with deadlocks is solved by using two threads.