### PR TITLE
fix: correct guidance for debuginfo and unit tests

### DIFF
--- a/src/bin/cargo-flamegraph.rs
+++ b/src/bin/cargo-flamegraph.rs
@@ -202,7 +202,13 @@ fn workload(opt: &Opt, artifacts: &[Artifact]) -> anyhow::Result<Vec<String>> {
 
     const NONE: u32 = 0;
     if !opt.dev && debug_level.unwrap_or(NONE) == NONE {
-        let profile = match opt.example.as_ref().or(opt.bin.as_ref()) {
+        let profile = match opt
+            .example
+            .as_ref()
+            .or(opt.bin.as_ref())
+            .or_else(|| opt.unit_test.as_ref().unwrap_or(&None).as_ref())
+        {
+            // binaries, examples and unit tests use release profile
             Some(_) => "release",
             // tests use the bench profile in release mode.
             _ => "bench",


### PR DESCRIPTION
Currently, when calling `cargo flamegraph --unit-test -- path::to::test` one gets a warning to enable debug symbols for the bench profile:

```
WARNING: profiling without debuginfo. Enable symbol information by adding the following lines to Cargo.toml:

[profile.bench]
debug = true

Or set this environment variable:

CARGO_PROFILE_BENCH_DEBUG=true
```
However, unit tests are actually run using `cargo test --release` internally, so the above message should reference `profile.release`.

This PR extends the check on what to print for unit tests.

Sidenote: The `or_else` in check below is to adhere to clippy, since the call is too long for a simple or, happy if someone has a more concise alternative.