### PR TITLE
Improve 'perf script' failure error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,10 +124,15 @@ mod arch {
             command.arg(perf_output);
         }
 
-        Ok(command
-            .output()
-            .context("unable to call perf script")?
-            .stdout)
+        let output = command.output().context("unable to call perf script")?;
+        if !output.status.success() {
+            anyhow::bail!(format!(
+                "unable to run 'perf script': ({}) {}",
+                output.status,
+                std::str::from_utf8(&output.stderr)?
+            ));
+        }
+        Ok(output.stdout)
     }
 }
 


### PR DESCRIPTION
Report an error when running `perf script` on the `perf.data` file fails. Currently when `perf script` fails it just passes empty data on to `inferno` which results in an unclear error about missing stack data.

Instead, this change checks the exit status of `perf script` and immediately exits if it failed.

This fixes https://github.com/flamegraph-rs/flamegraph/issues/226.