### PR TITLE
Add no-op --release flag for compatibility with `cargo run --release`

### DIFF
--- a/src/bin/cargo-flamegraph.rs
+++ b/src/bin/cargo-flamegraph.rs
@@ -50,6 +50,10 @@ struct Opt {
     #[clap(long)]
     no_default_features: bool,
 
+    /// No-op. For compatibility with `cargo run --release`.
+    #[clap(short, long)]
+    release: bool,
+
     #[clap(flatten)]
     graph: flamegraph::Options,
 


### PR DESCRIPTION
See #232 