### PR TITLE
Correctly identify named unit test targets

### DIFF
--- a/src/bin/cargo-flamegraph.rs
+++ b/src/bin/cargo-flamegraph.rs
@@ -344,9 +344,10 @@ fn find_unique_target(
                     None => true,
                     Some(default_name) => &t.name == default_name,
                 };
-                let name_filter = target_name
-                    .map(|target_name| t.name == target_name)
-                    .unwrap_or(true);
+                let name_filter = match target_name {
+                    None => true,
+                    Some(target_name) => t.name == target_name
+                };
                 (ok_kind && default_filter && name_filter).then(|| BinaryTarget {
                     package: name.clone(),
                     target: t.name,

--- a/src/bin/cargo-flamegraph.rs
+++ b/src/bin/cargo-flamegraph.rs
@@ -346,7 +346,7 @@ fn find_unique_target(
                 };
                 let name_filter = match target_name {
                     None => true,
-                    Some(target_name) => t.name == target_name
+                    Some(target_name) => t.name == target_name,
                 };
                 (ok_kind && default_filter && name_filter).then(|| BinaryTarget {
                     package: name.clone(),


### PR DESCRIPTION
The `--unit-test` flag (with no argument) only works in crates with a single target. In crates with multiple targets, the flag results in a `several possible targets found` error. If a specific target name is passed as an argument to `--unit-test`, the tool always passes the `--bin` flag to Cargo, which fails for `lib` targets.

This PR changes the behavior when an argument is passed to `--unit-test` to resolve the name to the corresponding target in order to determine whether to pass the `--lib` or `--bin` flag to Cargo.

Fixes #211.