### PR TITLE
Update blondie to v0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ shlex = "1.1.0"
 signal-hook = "0.3.10"
 
 [target.'cfg(windows)'.dependencies]
-blondie = "0.3.0"
+blondie = "0.4.0"
 
 [profile.release.build-override]
 opt-level = 0

--- a/deny.toml
+++ b/deny.toml
@@ -2,3 +2,15 @@
 allow-osi-fsf-free = "either"
 copyleft = "warn"
 allow = ["CDDL-1.0"]
+
+[[licenses.clarify]]
+name = "ring"
+# SPDX considers OpenSSL to encompass both the OpenSSL and SSLeay licenses
+# https://spdx.org/licenses/OpenSSL.html
+# ISC - Both BoringSSL and ring use this for their new files
+# MIT - "Files in third_party/ have their own licenses, as described therein. The MIT
+# license, for third_party/fiat, which, unlike other third_party directories, is
+# compiled into non-test libraries, is included below."
+# OpenSSL - Obviously
+expression = "ISC AND MIT AND OpenSSL"
+license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]


### PR DESCRIPTION
Fixes https://github.com/flamegraph-rs/flamegraph/issues/207

Blondie now uses the [pdb-addr2line](https://crates.io/crates/pdb-addr2line) and [symsrv](https://crates.io/crates/symsrv) crates instead of microsoft's dbghelp.dll for symbol resolution. This is faster, and resolved a couple bugs.

