### PR TITLE
Pretty print the possible targets to improve readability

### DIFF
--- a/src/bin/cargo-flamegraph.rs
+++ b/src/bin/cargo-flamegraph.rs
@@ -378,7 +378,7 @@ fn find_unique_target(
                 or similar to choose a binary"
         )),
         _ => Err(anyhow!(
-            "several possible targets found: {:?}, please pass an explicit target.",
+            "several possible targets found: {:#?}, please pass an explicit target.",
             targets
         )),
     }


### PR DESCRIPTION
I tried it on a personal project and the prompt went from 
```
Error: several possible targets found: [BinaryTarget { package: "linux", target: "linux", kind: ["bin"] }, BinaryTarget { package: "tui", target: "tui", kind: ["bin"] }], please pass an explicit target.
```
to
```
Error: several possible targets found: [
    BinaryTarget {
        package: "linux",
        target: "linux",
        kind: [
            "bin",
        ],
    },
    BinaryTarget {
        package: "tui",
        target: "tui",
        kind: [
            "bin",
        ],
    },
], please pass an explicit target.
```
Remember, this would make an even bigger difference if their were more binaries.