### PR TITLE
Add support for profiling unit-test style benchmarks

### DIFF
--- a/src/bin/cargo-flamegraph.rs
+++ b/src/bin/cargo-flamegraph.rs
@@ -74,7 +74,7 @@ enum Cli {
     Flamegraph(Opt),
 }
 
-fn build(opt: &Opt, kind: impl IntoIterator<Item = String>) -> anyhow::Result<Vec<Artifact>> {
+fn build(opt: &Opt, kind: Vec<String>) -> anyhow::Result<Vec<Artifact>> {
     use std::process::{Command, Output, Stdio};
     let mut cmd = Command::new("cargo");
 
@@ -121,7 +121,7 @@ fn build(opt: &Opt, kind: impl IntoIterator<Item = String>) -> anyhow::Result<Ve
     }
 
     if let Some(Some(ref unit_test)) = opt.unit_test {
-        match kind.into_iter().any(|k| k == "lib") {
+        match kind.iter().any(|k| k == "lib") {
             true => cmd.arg("--lib"),
             false => cmd.args(&["--bin", unit_test]),
         };

--- a/src/bin/cargo-flamegraph.rs
+++ b/src/bin/cargo-flamegraph.rs
@@ -81,9 +81,9 @@ fn build(opt: &Opt, kind: Vec<String>) -> anyhow::Result<Vec<Artifact>> {
     // This will build benchmarks with the `bench` profile. This is needed
     // because the `--profile` argument for `cargo build` is unstable.
     if !opt.dev && opt.bench.is_some() {
-        cmd.args(&["bench", "--no-run"]);
+        cmd.args(["bench", "--no-run"]);
     } else if opt.unit_test.is_some() {
-        cmd.args(&["test", "--no-run"]);
+        cmd.args(["test", "--no-run"]);
     } else {
         cmd.arg("build");
     }
@@ -123,7 +123,7 @@ fn build(opt: &Opt, kind: Vec<String>) -> anyhow::Result<Vec<Artifact>> {
     if let Some(Some(ref unit_test)) = opt.unit_test {
         match kind.iter().any(|k| k == "lib") {
             true => cmd.arg("--lib"),
-            false => cmd.args(&["--bin", unit_test]),
+            false => cmd.args(["--bin", unit_test]),
         };
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -373,7 +373,7 @@ pub fn generate_flamegraph_for_workload(workload: Workload, opts: Options) -> an
             .ok_or_else(|| anyhow!("unable to parse post-process command"))?;
 
         let mut child = Command::new(
-            &command_vec
+            command_vec
                 .get(0)
                 .ok_or_else(|| anyhow!("unable to parse post-process command"))?,
         )


### PR DESCRIPTION
This change extends the program with support for profiling unit test
benchmarks, aka libtest benchmarks. Support is accomplished in a vein
similar to that of unit tests: we introduce the `--unit-bench` argument
that behaves very much like the existing `--unit-test` does, but invokes
benchmarks instead of tests.
We cannot piggy-back on the existing `--bench` argument for the same
reason (presumably) that `--unit-test` is separate from `--test`: `--bench`
and `--test` require a target to be provided, but `--unit-test` and
`--unit-bench` can work without an argument or can be a pattern of tests
to match against, but not a target.