### PR TITLE
Optional sudo flags as --root argument

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,7 +148,7 @@ mod arch {
 
     pub(crate) fn initial_command(
         workload: Workload,
-        sudo: bool,
+        sudo: Option<Option<String>>,
         freq: Option<u32>,
         custom_cmd: Option<String>,
         verbose: bool,
@@ -156,8 +156,11 @@ mod arch {
     ) -> Option<String> {
         let dtrace = env::var("DTRACE").unwrap_or_else(|_| "dtrace".to_string());
 
-        let mut command = if sudo {
+        let mut command = if let Some(sudo) = sudo {
             let mut c = Command::new("sudo");
+            if let Some(sudo_args) = sudo {
+                c.arg(sudo_args);
+            }
             c.arg(&dtrace);
             c
         } else {
@@ -332,6 +335,7 @@ pub fn generate_flamegraph_for_workload(workload: Workload, opts: Options) -> an
         signal_hook::low_level::register(SIGINT, || {}).expect("cannot register signal handler")
     };
 
+    let use_sudo = opts.root.is_some();
     let perf_output = if let Workload::ReadPerf(perf_file) = workload {
         Some(perf_file)
     } else {
@@ -348,7 +352,7 @@ pub fn generate_flamegraph_for_workload(workload: Workload, opts: Options) -> an
     #[cfg(unix)]
     signal_hook::low_level::unregister(handler);
 
-    let output = arch::output(perf_output, opts.script_no_inline, opts.root)?;
+    let output = arch::output(perf_output, opts.script_no_inline, use_sudo)?;
 
     let perf_reader = BufReader::new(&*output);
 
@@ -451,9 +455,9 @@ pub struct Options {
     #[clap(long)]
     open: bool,
 
-    /// Run with root privileges (using `sudo`)
-    #[clap(long)]
-    root: bool,
+    /// Run with root privileges (using `sudo`). Accepts an optional argument containing command line options which will be passed to sudo
+    #[clap(long, value_name = "SUDO FLAGS")]
+    root: Option<Option<String>>,
 
     /// Sampling frequency
     #[clap(short = 'F', long = "freq")]


### PR DESCRIPTION
Thank you for this useful tool! :)

This PR allows to configure the sudo behavior when `--root` is used so one can provide additional command-line flags which will be passed to "sudo".
This is especially useful when preserving environment is needed: `cargo flamegraph --root='--preserve-env' --bin my-bin` (so this provides a solution for #47 ).