### PR TITLE
Add bash marker to make README more readable

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ flamegraph --completions bash > $XDG_CONFIG_HOME/bash_completion # or /etc/bash_
 
 ## Examples
 
-```
+```bash
 # if you'd like to profile an arbitrary executable:
 flamegraph [-o my_flamegraph.svg] -- /path/to/my/binary --my-arg 5
 


### PR DESCRIPTION
This PR adds a bash marker to the examples sections in the README.
With a bash marker the comments have a different color from the code, which makes it easier to distinguish between them.

This is more readable:
```bash
# or if the executable is already running, you can provide the PID via `-p` (or `--pid`) flag:
flamegraph [-o my_flamegraph.svg] --pid 1337

# NOTE: By default, perf tries to compute which functions are
# inlined at every stack frame for every sample. This can take
# a very long time (see https://github.com/flamegraph-rs/flamegraph/issues/74).
# If you don't want this, you can pass --no-inline to flamegraph:
flamegraph --no-inline [-o my_flamegraph.svg] /path/to/my/binary --my-arg 5
```

Than this:
```
# or if the executable is already running, you can provide the PID via `-p` (or `--pid`) flag:
flamegraph [-o my_flamegraph.svg] --pid 1337

# NOTE: By default, perf tries to compute which functions are
# inlined at every stack frame for every sample. This can take
# a very long time (see https://github.com/flamegraph-rs/flamegraph/issues/74).
# If you don't want this, you can pass --no-inline to flamegraph:
flamegraph --no-inline [-o my_flamegraph.svg] /path/to/my/binary --my-arg 5
```