### PR TITLE
Add ability to customize title and subtitle of generated graph

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -527,6 +527,14 @@ impl Options {
 
 #[derive(Debug, Args)]
 pub struct FlamegraphOptions {
+    /// Set title text in SVG
+    #[clap(long, value_name = "STRING")]
+    pub title: Option<String>,
+
+    /// Set second level title text in SVG
+    #[clap(long, value_name = "STRING")]
+    pub subtitle: Option<String>,
+
     /// Colors are selected such that the color of a function does not change between runs
     #[clap(long)]
     pub deterministic: bool,
@@ -571,6 +579,10 @@ pub struct FlamegraphOptions {
 impl FlamegraphOptions {
     pub fn into_inferno(self) -> inferno::flamegraph::Options<'static> {
         let mut options = inferno::flamegraph::Options::default();
+        if let Some(title) = self.title {
+            options.title = title;
+        }
+        options.subtitle = self.subtitle;
         options.deterministic = self.deterministic;
         if self.inverted {
             options.direction = inferno::flamegraph::Direction::Inverted;


### PR DESCRIPTION
As suggested in #223 it would be nice to support `--title` command line argument to set graph title in produced SVG image. To make flamegraph even more compatible with original flamegraph.pl here `--subtitle` command line argument is added as well.