### PR TITLE
Suppress output of `perf --help` during discovery

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,13 @@ mod arch {
         let perf = if let Ok(path) = env::var("PERF") {
             path
         } else {
-            if Command::new("perf").arg("--help").status().is_err() {
+            if Command::new("perf")
+                .arg("--help")
+                .stderr(Stdio::null())
+                .stdout(Stdio::null())
+                .status()
+                .is_err()
+            {
                 eprintln!("perf is not installed or not present in $PATH");
                 exit(1);
             }


### PR DESCRIPTION
Without this the output is printed to stderr, where it's just confusing.

We already do this for dtrace.