### PR TITLE
Increase dwarf stack size sample from 16k to 64k

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,7 @@ mod arch {
         };
         let mut command = sudo_command(&perf, sudo);
 
-        let args = custom_cmd.unwrap_or(format!("record -F {freq} --call-graph dwarf,16384 -g"));
+        let args = custom_cmd.unwrap_or(format!("record -F {freq} --call-graph dwarf,64000 -g"));
 
         let mut perf_output = None;
         let mut args = args.split_whitespace();


### PR DESCRIPTION
Async Rust code tends to have very bloated stack frames, especially without LTO.

Here's an example from one of our production services, where we see truncated stacks. There's a single mega-frame that's 122,336 bytes long (0x7f5dc09fd940 - 0x7f5dc09dfb60). It's frames 3 and 4 inlined into 5:

```
(gdb) bt
    at /home/builder/.cargo/registry/src/freighter.rust.cfdata.org-44762c5030e26881/tokio-quiche-0.21.0/src/quic/io/worker.rs:487
    at /home/builder/.cargo/registry/src/freighter.rust.cfdata.org-44762c5030e26881/tokio-quiche-0.21.0/src/quic/io/worker.rs:152
    at /home/builder/.cargo/registry/src/index.crates.io-6f17d22bba15001f/foundations-4.1.1/src/telemetry/telemetry_context.rs:41
...
```

```
(gdb) info frame 3
Stack frame at 0x7f5dc09fd940:
 rip = 0x5555cb04d86d
    in tokio_quiche::quic::io::worker::{impl#0}::work_loop::{async_fn#0}<tokio::net::udp::UdpSocket, oxy_telemetry::metrics::quic::OxyQuicMetrics, tokio_quiche::quic::io::connection_stage::RunningApplication, tokio_quiche::http3::driver::H3Driver<tokio_quiche::http3::driver::server::ServerHooks>> (/home/builder/.cargo/registry/src/freighter.rust.cfdata.org-44762c5030e26881/tokio-quiche-0.21.0/src/quic/io/worker.rs:152);
    saved rip = 0x5555cb3e2367
 inlined into frame 4, caller of frame at 0x7f5dc09dfb60
 source language rust.
 Arglist at unknown address.
 Locals at unknown address, Previous frame's sp is 0x7f5dc09dfb60
 Saved registers:
  rbx at 0x7f5dc09dfb28, rbp at 0x7f5dc09dfb50, r12 at 0x7f5dc09dfb30, r13 at 0x7f5dc09dfb38, r14 at 0x7f5dc09dfb40, r15 at 0x7f5dc09dfb48, rip at 0x7f5dc09dfb58

(gdb) info frame 4
Stack frame at 0x7f5dc09fd940:
 rip = 0x5555cb04d86d
    in tokio_quiche::quic::io::worker::{impl#4}::run::{async_fn#0}<tokio::net::udp::UdpSocket, oxy_telemetry::metrics::quic::OxyQuicMetrics, tokio_quiche::http3::driver::H3Driver<tokio_quiche::http3::driver::server::ServerHooks>> (/home/builder/.cargo/registry/src/freighter.rust.cfdata.org-44762c5030e26881/tokio-quiche-0.21.0/src/quic/io/worker.rs:696); saved rip = 0x5555cb3e2367
 inlined into frame 5, caller of frame at 0x7f5dc09fd940
 source language rust.
 Arglist at unknown address.
 Locals at unknown address, Previous frame's sp is 0x7f5dc09dfb60
 Saved registers:
  rbx at 0x7f5dc09dfb28, rbp at 0x7f5dc09dfb50, r12 at 0x7f5dc09dfb30, r13 at 0x7f5dc09dfb38, r14 at 0x7f5dc09dfb40, r15 at 0x7f5dc09dfb48, rip at 0x7f5dc09dfb58

(gdb) info frame 5
Stack frame at 0x7f5dc09fd940:
 rip = 0x5555cb04d86d
    in tokio_quiche::quic::connection::{impl#1}::resume::{async_block#0}<tokio::net::udp::UdpSocket, oxy_telemetry::metrics::quic::OxyQuicMetrics, tokio_quiche::http3::driver::H3Driver<tokio_quiche::http3::driver::server::ServerHooks>> (/home/builder/.cargo/registry/src/freighter.rust.cfdata.org-44762c5030e26881/tokio-quiche-0.21.0/src/quic/connection/mod.rs:227); saved rip = 0x5555cb3e2367
 called by frame at 0x7f5dc09fd9f0, caller of frame at 0x7f5dc09fd940
 source language rust.
 Arglist at 0x7f5dc09dfb60, args:
 Locals at 0x7f5dc09dfb60, Previous frame's sp is 0x7f5dc09fd940
 Saved registers:
  rbx at 0x7f5dc09fd908, rbp at 0x7f5dc09fd930, r12 at 0x7f5dc09fd910, r13 at 0x7f5dc09fd918, r14 at 0x7f5dc09fd920, r15 at 0x7f5dc09fd928, rip at 0x7f5dc09fd938
```

Currently we use 16k as the sample size for the stacks. Unfortunately, perf is unable to capture more than 64k bytes worth of stack due to the interface limitations, where the size of the captured stack lives in a u16 field.

Having 64k is still better than nothing.