### PR TITLE
Run stacks through rustc_demangle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,6 +515,7 @@ dependencies = [
  "indicatif",
  "inferno",
  "opener",
+ "rustc-demangle",
  "shlex",
  "signal-hook",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ indicatif = "0.17.8"
 inferno = { version = "0.12", default-features = false, features = ["multithreaded", "nameattr"] }
 opener = "0.7.1"
 shlex = "1.1.0"
+rustc-demangle = { version = "0.1", features = ["std"] }
 
 [target.'cfg(unix)'.dependencies]
 signal-hook = "0.3.10"


### PR DESCRIPTION
This enables proper demangling of `RUSTFLAGS=-Csymbol-mangling-version=v0`, especially on macOS where the binary name is included in the frames.

Closes #362.