### PR TITLE
Use `xctrace` on macOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ cargo_metadata = "0.19"
 clap = { version = "4.0.11", features = ["derive"] }
 clap_complete = "4.0.2"
 indicatif = "0.17.8"
-inferno = { version = "0.12", default-features = false, features = ["multithreaded", "nameattr"] }
+inferno = { version = "0.12.2", default-features = false, features = ["multithreaded", "nameattr"] }
 opener = "0.7.1"
 shlex = "1.1.0"
 rustc-demangle = { version = "0.1", features = ["std"] }

--- a/src/bin/cargo-flamegraph.rs
+++ b/src/bin/cargo-flamegraph.rs
@@ -476,13 +476,6 @@ fn main() -> anyhow::Result<()> {
         Vec::new()
     };
 
-    #[cfg(target_os = "macos")]
-    if let None = opt.graph.root {
-        return Err(anyhow!(
-            "DTrace requires elevated permissions on MacOS; re-invoke using 'cargo flamegraph --root ...'",
-        ));
-    }
-
     let artifacts = build(&opt, kind)?;
     let workload = workload(&opt, &artifacts)?;
     flamegraph::generate_flamegraph_for_workload(Workload::Command(workload), opt.graph)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,10 @@ use std::os::unix::process::ExitStatusExt;
 #[cfg(target_os = "linux")]
 use inferno::collapse::perf::{Folder, Options as CollapseOptions};
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(target_os = "macos")]
+use inferno::collapse::xctrace::Folder;
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
 use inferno::collapse::dtrace::{Folder, Options as CollapseOptions};
 
 #[cfg(unix)]
@@ -167,7 +170,87 @@ mod arch {
     }
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(target_os = "macos")]
+mod arch {
+    use super::*;
+
+    pub const SPAWN_ERROR: &str = "could not spawn xctrace";
+    pub const WAIT_ERROR: &str = "unable to wait for xctrace record child command to exit";
+
+    pub(crate) fn initial_command(
+        workload: Workload,
+        sudo: Option<Option<&str>>,
+        _freq: u32,
+        _custom_cmd: Option<String>,
+        verbose: bool,
+        ignore_status: bool,
+    ) -> Option<PathBuf> {
+        let xctrace = env::var("XCTRACE").unwrap_or_else(|_| "xctrace".to_string());
+        let trace_file = PathBuf::from("cargo-flamegraph.trace");
+        let mut command = sudo_command(&xctrace, sudo);
+        command
+            .arg("record")
+            .arg("--template")
+            .arg("Time Profiler")
+            .arg("--target-stdout")
+            .arg("-")
+            .arg("--output")
+            .arg(&trace_file);
+        match workload {
+            Workload::Command(args) => {
+                command.arg("--launch").arg("--").args(args);
+            }
+            Workload::Pid(pid) => {
+                match &*pid {
+                    [pid] => {
+                        // xctrace could accept multiple --attach <pid> arguments,
+                        // but it will only profiling on the last pid provided.
+                        command.arg("--attach").arg(pid.to_string());
+                    }
+                    _ => {
+                        panic!("xctrace only supports profiling a single process at a time");
+                    }
+                }
+            }
+            Workload::ReadPerf(_) => {}
+        }
+        run(command, verbose, ignore_status);
+        Some(trace_file)
+    }
+
+    pub fn output(
+        trace_file: Option<PathBuf>,
+        script_no_inline: bool,
+        _sudo: Option<Option<&str>>,
+    ) -> anyhow::Result<Vec<u8>> {
+        if script_no_inline {
+            return Err(anyhow::anyhow!("--no-inline is only supported on Linux"));
+        }
+
+        let xctrace = env::var("XCTRACE").unwrap_or_else(|_| "xctrace".to_string());
+        let trace_file = trace_file.context("No trace file found.")?;
+        let output = Command::new(xctrace)
+            .arg("export")
+            .arg("--input")
+            .arg(&trace_file)
+            .arg("--xpath")
+            .arg(r#"/trace-toc/*/data/table[@schema="time-profile"]"#)
+            .output()
+            .context("Run xctrace export failed.")?;
+        std::fs::remove_dir_all(&trace_file)
+            .with_context(|| anyhow!("Remove trace({}) failed.", trace_file.to_string_lossy()))?;
+        if !output.status.success() {
+            anyhow::bail!(format!(
+                "unable to run 'xctrace export': ({}) {}",
+                output.status,
+                String::from_utf8_lossy(&output.stderr)
+            ));
+        }
+        Ok(output.stdout)
+    }
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
 mod arch {
     use super::*;
 
@@ -359,7 +442,10 @@ fn run(mut command: Command, verbose: bool, ignore_status: bool) {
     // latter case usually means the user interrupted
     // it in some way)
     if !ignore_status && terminated_by_error(exit_status) {
-        eprintln!("failed to sample program");
+        eprintln!(
+            "failed to sample program, exited with code: {:?}",
+            exit_status.code()
+        );
         exit(1);
     }
 }
@@ -370,6 +456,8 @@ fn terminated_by_error(status: ExitStatus) -> bool {
         .signal() // the default needs to be true because that's the neutral element for `&&`
         .map_or(true, |code| code != SIGINT && code != SIGTERM)
         && !status.success()
+        // on macOS, xctrace captures Ctrl+C and exits with code 54
+        && !(cfg!(target_os = "macos") && status.code() == Some(54))
 }
 
 #[cfg(not(unix))]
@@ -426,15 +514,23 @@ pub fn generate_flamegraph_for_workload(workload: Workload, opts: Options) -> an
 
     let collapsed_writer = BufWriter::new(&mut collapsed);
 
-    #[allow(unused_mut)]
-    let mut collapse_options = CollapseOptions::default();
-
     #[cfg(target_os = "linux")]
-    {
+    let mut folder = {
+        let mut collapse_options = CollapseOptions::default();
         collapse_options.skip_after = opts.flamegraph_options.skip_after.clone();
-    }
+        Folder::from(collapse_options)
+    };
 
-    Folder::from(collapse_options)
+    #[cfg(target_os = "macos")]
+    let mut folder = Folder::default();
+
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    let mut folder = {
+        let collapse_options = CollapseOptions::default();
+        Folder::from(collapse_options)
+    };
+
+    folder
         .collapse(perf_reader, collapsed_writer)
         .context("unable to collapse generated profile data")?;
 


### PR DESCRIPTION
Now that https://github.com/jonhoo/inferno/pull/286 has been merged, we can switch to `xctrace` backend on macOS. The major difference is that xctrace no longer requires root right.

fixes #192 

e.g. A flameggraph of https://github.com/serde-rs/json-benchmark:
 
![flamegraph_xctrace](https://github.com/user-attachments/assets/6a4ef4d0-0c41-42b9-9767-7244d66b10ae)
