### PR TITLE
doc: Remove mention of sudo/root from macOS installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ How to use flamegraphs: [what's a flamegraph, and how can I use it to guide syst
 \[cargo-\]flamegraph supports
 
 - [Linux](#linux): relies on `perf`
-- [MacOS](#macos): relies on `dtrace`
+- [MacOS](#macos): relies on `xctrace`
 - [Windows](#windows): native support with the [blondie](https://github.com/nico-abram/blondie) library; also works with `dtrace` on Windows
 
 `cargo install flamegraph` will make the `flamegraph` and `cargo-flamegraph` binaries available in

--- a/README.md
+++ b/README.md
@@ -83,18 +83,6 @@ sudo apt install linux-tools-raspi
 sudo apt install linux-tools-common linux-tools-generic
 ```
 
-## MacOS
-
-#### DTrace on macOS
-
-On macOS, there is no alternative to running as superuser in order to
-enable DTrace. This should be done by invoking `sudo flamegraph ...` or
-`cargo flamegraph --root ...`. Do not do `sudo cargo flamegraph ...`;
-this can cause problems due to Cargo's build system being run as root.
-
-Be aware that if the binary being tested is user-aware, this does
-change its behaviour.
-
 ## Windows
 
 #### Blondie Backend


### PR DESCRIPTION
Root/sudo is no longer required on macOS since https://github.com/flamegraph-rs/flamegraph/pull/374 was merged.

Hence, the section of the README that explained why that was necessary can be removed.