### PR TITLE
Update in readme info on new default linker and old debian releases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1409,9 +1409,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/README.md
+++ b/README.md
@@ -39,7 +39,16 @@ your cargo binary directory. On most systems this is something like `~/.cargo/bi
 
 ## Linux
 
-**Note**: If you're using lld or mold on Linux, you must use the `--no-rosegment` flag. Otherwise perf will not be able to generate accurate stack traces ([explanation](https://crbug.com/919499#c16)). For example, for lld:
+**Note**: If you're using lld (which is the default since Rust 1.90.0) or mold on Linux, you must use the `--no-rosegment` flag. Otherwise perf will not be able to generate accurate stack traces ([explanation](https://crbug.com/919499#c16)).
+
+For example, Rust 1.90.0 and later:
+
+```toml
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-Clink-arg=-Wl,--no-rosegment"]
+```
+
+for explicitly configured lld on older toolchains:
 
 ```toml
 [target.x86_64-unknown-linux-gnu]
@@ -57,7 +66,7 @@ rustflags = ["-Clink-arg=-fuse-ld=/usr/local/bin/mold", "-Clink-arg=-Wl,--no-ros
 
 #### Debian (x86 and aarch)
 
-**Note**: Debian bullseye (the current stable version as of 2022) packages an outdated version of Rust which does not meet flamegraph's requirements. You should use [rustup](https://rustup.rs/) to install an up-to-date version of Rust, or upgrade to Debian bookworm (the current testing version) or newer.
+**Note**: Debian bullseye packages an outdated version of Rust which does not meet flamegraph's requirements. You should use [rustup](https://rustup.rs/) to install an up-to-date version of Rust, or upgrade to Debian bookworm or newer.
 
 ```bash
 sudo apt install -y linux-perf


### PR DESCRIPTION
- `lld` linker is now the default so I tried to make it clearer that people have to add the configuration for flamegraphs to work proprely without explicitly setting the linker.
- `bullseye` is not stable, it's even past its EOL now and in another 5 months it will be past its extended EOL. Personally, I would probably just remove the note altogether, but I didn't want to do that on my own since people could conceivably still use it so it you want me to, I'll delete it, otherwise I'm just removing the stable/testing notes about bullseye and bookworm.