### PR TITLE
fix(macos): drop Event::Empty arm in demangle_stream that corrupted x…

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -506,7 +506,6 @@ fn demangle_stream<R: BufRead, W: Write>(input: &mut R, output: &mut W) -> std::
         let start = match reader.read_event_into(&mut buf) {
             Ok(Event::Eof) => break,
             Ok(Event::Start(start)) => start,
-            Ok(Event::Empty(start)) => start,
             Ok(el) => {
                 writer.write_event(el)?;
                 continue;


### PR DESCRIPTION
The Event::Empty arm (self-closing tags like <binary .../>) was matched to 'start' and then written as Event::Start without a corresponding closing tag, producing malformed XML that broke inferno's xctrace collapser with IllFormed(MismatchedEndTag).

This broke profiling of C++ binaries on macOS.

This should fix https://github.com/flamegraph-rs/flamegraph/issues/445

Ive tested this with c++ and rust binaries but please lmk if more coverage would help